### PR TITLE
Add MP3 loading support to editable audio workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # WavConvert4Amiga
 
-A Windows utility designed to convert WAV files for optimal use with Amiga computers and music trackers. Features an intuitive interface for sample rate conversion, waveform editing, and ProTracker note tuning.
+A Windows utility designed to convert WAV/MP3 files for optimal use with Amiga computers and music trackers. Features an intuitive interface for sample rate conversion, waveform editing, and ProTracker note tuning.
 
 ![WavConvert4Amiga GUI v1.2](wc4a-gui-1.2.jpeg?raw=true "Title")
 ## Features
 
 ### Audio Processing
 - Convert WAV files to 8-bit mono format at any sample rate
+- Load MP3 files and decode them into the same editable workflow as WAV files
 - Support for both PAL and NTSC frequencies
 - ProTracker note frequency conversion (C-1 to B-3)
 - Built-in low-pass filter option
@@ -28,7 +29,7 @@ A Windows utility designed to convert WAV files for optimal use with Amiga compu
 - Visual feedback during recording
 
 ### File Handling
-- Drag and drop WAV file support
+- Drag and drop WAV/MP3 file support
 - Auto-convert option for batch processing
 - Original file preservation option
 - Save as WAV or 8SVX format
@@ -37,7 +38,7 @@ A Windows utility designed to convert WAV files for optimal use with Amiga compu
 ## Usage
 
 ### Basic Operation
-1. Drag and drop a WAV file onto the interface
+1. Drag and drop a WAV or MP3 file onto the interface
 2. Select desired sample rate or ProTracker note
 3. Adjust amplification if needed
 4. Enable low-pass filter if desired

--- a/WavConvert4Amiga/WavConvert4Amiga-Main.cs
+++ b/WavConvert4Amiga/WavConvert4Amiga-Main.cs
@@ -380,7 +380,7 @@ namespace WavConvert4Amiga
         {
             using (OpenFileDialog openFileDialog = new OpenFileDialog())
             {
-                openFileDialog.Filter = "All Supported Files|*.wav;*.8svx;*.iff|WAV files (*.wav)|*.wav|IFF/8SVX files (*.8svx;*.iff)|*.8svx;*.iff|ST Sample Files|*.*|All files (*.*)|*.*";
+                openFileDialog.Filter = "All Supported Files|*.wav;*.mp3;*.8svx;*.iff|WAV/MP3 files (*.wav;*.mp3)|*.wav;*.mp3|IFF/8SVX files (*.8svx;*.iff)|*.8svx;*.iff|ST Sample Files|*.*|All files (*.*)|*.*";
                 openFileDialog.FilterIndex = 1;
                 openFileDialog.Multiselect = true;
                 openFileDialog.Title = "Select Audio Files";
@@ -2615,6 +2615,25 @@ namespace WavConvert4Amiga
                         reader.Read(originalPcmData, 0, originalPcmData.Length);
                     }
                 }
+                else if (extension == ".mp3")
+                {
+                    // Decode MP3 files to PCM so they can use the same editing/conversion pipeline
+                    using (var reader = new MediaFoundationReader(filePath))
+                    using (var pcmBuffer = new MemoryStream())
+                    {
+                        originalFormat = reader.WaveFormat;
+                        originalSampleRate = reader.WaveFormat.SampleRate;
+
+                        byte[] buffer = new byte[16384];
+                        int bytesRead;
+                        while ((bytesRead = reader.Read(buffer, 0, buffer.Length)) > 0)
+                        {
+                            pcmBuffer.Write(buffer, 0, bytesRead);
+                        }
+
+                        originalPcmData = pcmBuffer.ToArray();
+                    }
+                }
                 else
                 {
                     throw new InvalidOperationException("Unsupported file format");
@@ -3598,7 +3617,7 @@ namespace WavConvert4Amiga
         {
             using (OpenFileDialog dialog = new OpenFileDialog())
             {
-                dialog.Filter = "Audio files (*.wav;*.8svx;*.iff)|*.wav;*.8svx;*.iff|All files (*.*)|*.*";
+                dialog.Filter = "Audio files (*.wav;*.mp3;*.8svx;*.iff)|*.wav;*.mp3;*.8svx;*.iff|All files (*.*)|*.*";
                 dialog.Multiselect = true;
 
                 if (dialog.ShowDialog() == DialogResult.OK)


### PR DESCRIPTION
### Motivation
- Allow users to load MP3 files and edit them in the same pipeline as WAVs so drag/drop and queue workflows can handle compressed audio transparently.
- Reuse the existing resample/edit/save path by decoding MP3 into PCM rather than implementing a separate MP3-specific editor path.

### Description
- Added `*.mp3` to the main load panel `OpenFileDialog` filter so MP3s appear in the file picker (changed `LoadPanel_Click` filter to include `*.mp3`).
- Extended `ProcessWaveFile` to detect `.mp3` files and decode them into PCM bytes using `MediaFoundationReader`, preserving `WaveFormat`/sample rate and feeding the resulting PCM into the existing resample/edit pipeline.
- Added `*.mp3` to the queue add-files dialog filter so MP3s can be batch-queued via the queue UI.
- Updated `README.md` to document WAV/MP3 support and updated drag-and-drop and usage text accordingly.

### Testing
- Attempted to build the solution with `dotnet build WavConvert4Amiga.sln` but the `dotnet` toolchain was not available in the environment so the build could not be run.
- Attempted to build with `msbuild WavConvert4Amiga.sln /t:Build /p:Configuration=Release` but `msbuild` was not available in the environment so the build could not be run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7edf8f60c832d9d5cf48458a9c7db)