### PR TITLE
Prefer in-memory decoded audio for queue resampling to avoid RIFF header errors

### DIFF
--- a/WavConvert4Amiga/WavConvert4Amiga-Main.cs
+++ b/WavConvert4Amiga/WavConvert4Amiga-Main.cs
@@ -2919,7 +2919,24 @@ namespace WavConvert4Amiga
                 byte[] pcmData;
                 var (oldStart, oldEnd) = waveformViewer.GetLoopPoints();
 
-                if (!string.IsNullOrEmpty(lastLoadedFilePath) && !isRecorded)
+                if (originalPcmData != null && originalFormat != null)
+                {
+                    using (var sourceMs = new MemoryStream())
+                    using (var writer = new WaveFileWriter(sourceMs, originalFormat))
+                    {
+                        writer.Write(originalPcmData, 0, originalPcmData.Length);
+                        writer.Flush();
+                        sourceMs.Position = 0;
+
+                        using (var reader = new WaveFileReader(sourceMs))
+                        using (var resampler = new MediaFoundationResampler(reader, new WaveFormat(targetSampleRate, 8, 1)))
+                        {
+                            resampler.ResamplerQuality = 60;
+                            pcmData = GetPCMData(resampler);
+                        }
+                    }
+                }
+                else if (!string.IsNullOrEmpty(lastLoadedFilePath) && !isRecorded)
                 {
                     string ext = Path.GetExtension(lastLoadedFilePath).ToLower();
                     if (ext == ".8svx")
@@ -2952,24 +2969,6 @@ namespace WavConvert4Amiga
                                 resampler.ResamplerQuality = 60;
                                 pcmData = GetPCMData(resampler);
                             }
-                        }
-                    }
-                }
-                else if (isRecorded && originalPcmData != null)
-                {
-                    using (var sourceMs = new MemoryStream())
-                    {
-                        // Write original data to memory stream
-                        var writer = new WaveFileWriter(sourceMs, originalFormat);
-                        writer.Write(originalPcmData, 0, originalPcmData.Length);
-                        writer.Flush();
-                        sourceMs.Position = 0;
-
-                        using (var reader = new WaveFileReader(sourceMs))
-                        using (var resampler = new MediaFoundationResampler(reader, new WaveFormat(targetSampleRate, 8, 1)))
-                        {
-                            resampler.ResamplerQuality = 60;
-                            pcmData = GetPCMData(resampler);
                         }
                     }
                 }


### PR DESCRIPTION
### Motivation
- The queue processing path attempted to reopen the original file as a WAV, which caused queued MP3 (and other decoded) items to fail with `Not a WAVE file - No RIFF header` when the file on disk was not a RIFF/WAV. 

### Description
- Updated `ProcessWithCurrentSampleRate` to prefer resampling from the already-decoded in-memory source by checking `originalPcmData` and `originalFormat` first and resampling from a `MemoryStream` containing that data. 
- Preserved the existing fallback that opens `lastLoadedFilePath` for file-based processing when in-memory data is not available. 
- Removed a now-redundant recorded-data branch so the in-memory path covers both previously-recorded and already-decoded files. 
- Change applied in `WavConvert4Amiga/WavConvert4Amiga-Main.cs` around the resampling selection logic.

### Testing
- Attempted to run `dotnet build WavConvert4Amiga.sln`, but the environment does not have the `dotnet` SDK installed so the build could not be executed.
- No other automated tests were available or run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7f00dc0a8832d9d20378b60b0b4d0)