### PR TITLE
Fix queue resampling for MP3 sources

### DIFF
--- a/WavConvert4Amiga/WavConvert4Amiga-Main.cs
+++ b/WavConvert4Amiga/WavConvert4Amiga-Main.cs
@@ -2919,10 +2919,30 @@ namespace WavConvert4Amiga
                 byte[] pcmData;
                 var (oldStart, oldEnd) = waveformViewer.GetLoopPoints();
 
-                if (!string.IsNullOrEmpty(lastLoadedFilePath) && !isRecorded)
+                if (!isRecorded && originalPcmData != null && originalFormat != null)
                 {
+                    using (var sourceMs = new MemoryStream())
+                    {
+                        using (var writer = new WaveFileWriter(sourceMs, originalFormat))
+                        {
+                            writer.Write(originalPcmData, 0, originalPcmData.Length);
+                            writer.Flush();
+                            sourceMs.Position = 0;
+
+                            using (var reader = new WaveFileReader(sourceMs))
+                            using (var resampler = new MediaFoundationResampler(reader, new WaveFormat(targetSampleRate, 8, 1)))
+                            {
+                                resampler.ResamplerQuality = 60;
+                                pcmData = GetPCMData(resampler);
+                            }
+                        }
+                    }
+                }
+                else if (!string.IsNullOrEmpty(lastLoadedFilePath) && !isRecorded)
+                {
+                    // Fallback path for older queue entries where in-memory source state is unavailable.
                     string ext = Path.GetExtension(lastLoadedFilePath).ToLower();
-                    if (ext == ".8svx")
+                    if (ext == ".8svx" || ext == ".iff")
                     {
                         var svxInfo = SVXLoader.Load8SVXFile(lastLoadedFilePath);
                         using (var sourceMs = new MemoryStream())
@@ -2943,24 +2963,30 @@ namespace WavConvert4Amiga
                             }
                         }
                     }
+                    else if (ext == ".mp3")
+                    {
+                        using (var reader = new MediaFoundationReader(lastLoadedFilePath))
+                        using (var resampler = new MediaFoundationResampler(reader, new WaveFormat(targetSampleRate, 8, 1)))
+                        {
+                            resampler.ResamplerQuality = 60;
+                            pcmData = GetPCMData(resampler);
+                        }
+                    }
                     else
                     {
                         using (var reader = new WaveFileReader(lastLoadedFilePath))
+                        using (var resampler = new MediaFoundationResampler(reader, new WaveFormat(targetSampleRate, 8, 1)))
                         {
-                            using (var resampler = new MediaFoundationResampler(reader, new WaveFormat(targetSampleRate, 8, 1)))
-                            {
-                                resampler.ResamplerQuality = 60;
-                                pcmData = GetPCMData(resampler);
-                            }
+                            resampler.ResamplerQuality = 60;
+                            pcmData = GetPCMData(resampler);
                         }
                     }
                 }
-                else if (isRecorded && originalPcmData != null)
+                else if (isRecorded && originalPcmData != null && originalFormat != null)
                 {
                     using (var sourceMs = new MemoryStream())
+                    using (var writer = new WaveFileWriter(sourceMs, originalFormat))
                     {
-                        // Write original data to memory stream
-                        var writer = new WaveFileWriter(sourceMs, originalFormat);
                         writer.Write(originalPcmData, 0, originalPcmData.Length);
                         writer.Flush();
                         sourceMs.Position = 0;


### PR DESCRIPTION
### Motivation
- Prevent queued MP3 files (already decoded to PCM on load) from being re-opened with `WaveFileReader` during "Convert All", which caused "Not a WAVE file - no RIFF header" errors.
- Ensure the conversion pipeline always resamples from a reliable PCM source (in-memory when available) so the main engine treats MP3 as a temporary decoded state.

### Description
- Changed `ProcessWithCurrentSampleRate` to prefer in-memory source data by using `originalPcmData` and `originalFormat` for non-recorded items when available, resampling via a `MemoryStream` + `WaveFileWriter` and `MediaFoundationResampler`.
- Added a fallback path that handles legacy/readonly queued items by checking `lastLoadedFilePath` and decoding `.8svx`/`.iff` via `SVXLoader`, `.mp3` via `MediaFoundationReader`, and other files via `WaveFileReader` before resampling.
- Tightened null checks on `originalPcmData` and `originalFormat` for the recorded branch to avoid unintended fallthroughs.
- Kept existing effects application and auto-save behavior unchanged while ensuring waveform/UI updates use the newly produced PCM buffer.

### Testing
- Attempted `dotnet build WavConvert4Amiga.sln`, but the `dotnet` CLI is not available in this environment so the build could not be executed.
- Attempted `msbuild WavConvert4Amiga.sln`, but `msbuild` is not available in this environment so the build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7f98cade0832db5012c63a2e3d481)