### PR TITLE
Make MainForm resizable and add adaptive UI scaling on window resize

### DIFF
--- a/WavConvert4Amiga/WavConvert4Amiga-Main.Designer.cs
+++ b/WavConvert4Amiga/WavConvert4Amiga-Main.Designer.cs
@@ -289,10 +289,10 @@
             this.Controls.Add(this.checkBoxEnable8SVX);
             this.Controls.Add(this.checkBox16BitWAV);
             this.DoubleBuffered = true;
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.Sizable;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.MaximizeBox = false;
+            this.MaximizeBox = true;
             this.Name = "MainForm";
             this.Text = "SoundConvert4Amiga";
             this.Load += new System.EventHandler(this.MainForm_Load);

--- a/WavConvert4Amiga/WavConvert4Amiga-Main.cs
+++ b/WavConvert4Amiga/WavConvert4Amiga-Main.cs
@@ -83,6 +83,8 @@ namespace WavConvert4Amiga
         private readonly Dictionary<QueueItem, DataGridViewRow> queueRows = new Dictionary<QueueItem, DataGridViewRow>();
         private bool isQueueRunning = false;
         private bool queueStopRequested = false;
+        private Size previousClientSize;
+        private bool isApplyingResizeScale = false;
 
 
         private Dictionary<string, (int pal, int ntsc)> ptNoteToHz = new Dictionary<string, (int pal, int ntsc)>()
@@ -249,10 +251,14 @@ namespace WavConvert4Amiga
                 comboBoxSampleRate.ForeColor = Color.FromArgb(180, 190, 210);
                 comboBoxSampleRate.Font = FontManager.GetMainFont(9f, FontStyle.Regular);
             }
+
+            previousClientSize = this.ClientSize;
+            this.Resize += MainForm_Resize;
         }
 
         private void MainForm_Load(object sender, EventArgs e)
         {
+            previousClientSize = this.ClientSize;
             panel1.AllowDrop = true;
             panel1.DragEnter += panel1_DragEnter;
             panel1.DragDrop += panel1_DragDrop;
@@ -273,6 +279,41 @@ namespace WavConvert4Amiga
 
             // Optionally select a default value
             comboBoxSampleRate.SelectedIndex = 5; // Select the first item by default
+        }
+
+        private void MainForm_Resize(object sender, EventArgs e)
+        {
+            if (isApplyingResizeScale)
+            {
+                return;
+            }
+
+            if (previousClientSize.Width <= 0 || previousClientSize.Height <= 0)
+            {
+                previousClientSize = this.ClientSize;
+                return;
+            }
+
+            float widthScale = (float)this.ClientSize.Width / previousClientSize.Width;
+            float heightScale = (float)this.ClientSize.Height / previousClientSize.Height;
+
+            if (Math.Abs(widthScale - 1f) < 0.001f && Math.Abs(heightScale - 1f) < 0.001f)
+            {
+                return;
+            }
+
+            try
+            {
+                isApplyingResizeScale = true;
+                this.SuspendLayout();
+                this.Scale(new SizeF(widthScale, heightScale));
+            }
+            finally
+            {
+                this.ResumeLayout(true);
+                isApplyingResizeScale = false;
+                previousClientSize = this.ClientSize;
+            }
         }
 
         private void InitializeCursors()


### PR DESCRIPTION
### Motivation
- The main window was fixed-size which makes the app awkward on laptop screens and smaller displays, so controls should scale when the user resizes the window. 
- Improve usability by allowing maximize and proportional resizing of controls and fonts rather than a static layout.

### Description
- Changed the main form border to a resizable window by switching `FormBorderStyle` from `FixedSingle` to `Sizable` and re-enabled `MaximizeBox` in `WavConvert4Amiga-Main.Designer.cs`.
- Added `previousClientSize` and `isApplyingResizeScale` fields to `MainForm` to track size and guard re-entrant/rescale operations.
- Hooked `this.Resize += MainForm_Resize` during initialization and set `previousClientSize` in the constructor and `MainForm_Load` to maintain a stable base for scaling.
- Implemented `MainForm_Resize` to compute `widthScale` and `heightScale`, ignore near-1.0 changes, guard re-entrancy, and call `this.Scale(new SizeF(widthScale, heightScale))` with layout suspend/resume to scale controls and fonts proportionally.

### Testing
- Attempted to build with `dotnet build WavConvert4Amiga.sln`, but `dotnet` is not available in this environment so the build could not be executed.
- Attempted to build with `msbuild WavConvert4Amiga.sln`, but `msbuild` is not available in this environment so the build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7fb0fe3a4832db8ed7c59fa949e21)