### PR TITLE
Add Chipify Mono and Chipify Deluxe synth effects and wire them into UI/processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ A Windows utility designed to convert WAV/MP3 files for optimal use with Amiga c
 - Load MP3 files and decode them into the same editable workflow as WAV files
 - Support for both PAL and NTSC frequencies
 - ProTracker note frequency conversion (C-1 to B-3)
+- Chipify Mono effect (single-note chip-style resynthesis with envelope following)
+- Chipify Deluxe effect (frame pitch-tracking with chip wave selection and resynthesis)
 - Built-in low-pass filter option
 - Adjustable amplification control
 - 8SVX file format support

--- a/WavConvert4Amiga/AudioEffectsProcessor.cs
+++ b/WavConvert4Amiga/AudioEffectsProcessor.cs
@@ -7,6 +7,12 @@ namespace WavConvert4Amiga
 {
     public class AudioEffectsProcessor
     {
+        private enum ChipWaveType
+        {
+            Pulse,
+            Triangle,
+            Saw
+        }
 
         private Action<string> setCursorCallback;
 
@@ -334,6 +340,142 @@ namespace WavConvert4Amiga
                 SetNormalCursor();
             }
         }
+
+        public byte[] ApplyChipifyMonoEffect(byte[] input, int sampleRate)
+        {
+            try
+            {
+                SetBusyCursor();
+                if (input == null || input.Length < 8)
+                {
+                    return input ?? Array.Empty<byte>();
+                }
+
+                float[] source = BytesToFloats(input);
+                float[] output = new float[source.Length];
+
+                float baseFrequency = EstimateFundamentalFrequency(source, sampleRate, 0, source.Length);
+                if (baseFrequency <= 0)
+                {
+                    baseFrequency = 220.0f;
+                }
+
+                baseFrequency = QuantizeFrequencyToSemitone(baseFrequency);
+
+                float env = 0f;
+                float attack = 0.18f;
+                float release = 0.996f;
+                float phase = 0f;
+                float increment = baseFrequency / Math.Max(1, sampleRate);
+
+                for (int i = 0; i < source.Length; i++)
+                {
+                    float abs = Math.Abs(source[i]);
+                    if (abs > env)
+                    {
+                        env = env + (abs - env) * attack;
+                    }
+                    else
+                    {
+                        env *= release;
+                    }
+
+                    phase += increment;
+                    if (phase >= 1f) phase -= 1f;
+
+                    float pulse = phase < 0.42f ? 1f : -1f;
+                    float tri = 1f - (4f * Math.Abs(phase - 0.5f));
+                    float mixed = (pulse * 0.75f) + (tri * 0.25f);
+
+                    output[i] = mixed * env * 0.95f;
+                }
+
+                return ConvertToBytes(output, 1.0f);
+            }
+            finally
+            {
+                SetNormalCursor();
+            }
+        }
+
+        public byte[] ApplyChipifyDeluxeEffect(byte[] input, int sampleRate)
+        {
+            try
+            {
+                SetBusyCursor();
+                if (input == null || input.Length < 8)
+                {
+                    return input ?? Array.Empty<byte>();
+                }
+
+                float[] source = BytesToFloats(input);
+                float[] output = new float[source.Length];
+
+                int frameSize = Math.Max(128, sampleRate / 50); // ~20ms
+                int hopSize = Math.Max(64, frameSize / 2);
+
+                float globalEnvelope = 0f;
+                float attack = 0.25f;
+                float release = 0.995f;
+                float phase = 0f;
+                float smoothedFreq = 220f;
+
+                for (int frameStart = 0; frameStart < source.Length; frameStart += hopSize)
+                {
+                    int frameEnd = Math.Min(source.Length, frameStart + frameSize);
+                    int frameLen = frameEnd - frameStart;
+                    if (frameLen < 32) break;
+
+                    float detected = EstimateFundamentalFrequency(source, sampleRate, frameStart, frameLen);
+                    float zcr = EstimateZeroCrossingRate(source, frameStart, frameLen);
+
+                    bool voiced = detected > 0 && zcr < 0.45f;
+                    if (voiced)
+                    {
+                        detected = QuantizeFrequencyToSemitone(detected);
+                        smoothedFreq = (smoothedFreq * 0.7f) + (detected * 0.3f);
+                    }
+
+                    ChipWaveType wave = SelectChipWaveType(zcr, voiced);
+                    float frameIncrement = smoothedFreq / Math.Max(1, sampleRate);
+
+                    int synthEnd = Math.Min(source.Length, frameStart + hopSize);
+                    for (int i = frameStart; i < synthEnd; i++)
+                    {
+                        float abs = Math.Abs(source[i]);
+                        if (abs > globalEnvelope)
+                        {
+                            globalEnvelope = globalEnvelope + (abs - globalEnvelope) * attack;
+                        }
+                        else
+                        {
+                            globalEnvelope *= release;
+                        }
+
+                        float sample;
+                        if (!voiced)
+                        {
+                            sample = (((i * 1103515245) + 12345) & 0x7fff) / 16384.0f - 1.0f;
+                            sample *= 0.5f;
+                        }
+                        else
+                        {
+                            phase += frameIncrement;
+                            if (phase >= 1f) phase -= 1f;
+                            sample = GenerateChipSample(wave, phase);
+                        }
+
+                        output[i] = sample * globalEnvelope * 0.95f;
+                    }
+                }
+
+                return ConvertToBytes(output, 1.0f);
+            }
+            finally
+            {
+                SetNormalCursor();
+            }
+        }
         private static readonly int[] vocalFreqs = { 200, 400, 800, 1600, 2400, 3200 }; // Key vocal frequencies
 
         // Apply vocal removal effect (using frequency-based approach for mono)
@@ -460,6 +602,139 @@ namespace WavConvert4Amiga
                 output[i] = (byte)Math.Max(0, Math.Min(255, (sample * 128.0f) + 128));
             }
             return output;
+        }
+
+        private float[] BytesToFloats(byte[] input)
+        {
+            float[] output = new float[input.Length];
+            for (int i = 0; i < input.Length; i++)
+            {
+                output[i] = (input[i] - 128) / 128.0f;
+            }
+            return output;
+        }
+
+        private float EstimateFundamentalFrequency(float[] source, int sampleRate, int start, int length)
+        {
+            if (length <= 0 || sampleRate <= 0)
+            {
+                return 0f;
+            }
+
+            int minLag = Math.Max(1, sampleRate / 1400); // ~1400 Hz
+            int maxLag = Math.Min(length - 2, sampleRate / 70); // ~70 Hz
+            if (maxLag <= minLag)
+            {
+                return 0f;
+            }
+
+            float best = 0f;
+            int bestLag = 0;
+
+            for (int lag = minLag; lag <= maxLag; lag++)
+            {
+                float corr = 0f;
+                float normA = 0f;
+                float normB = 0f;
+                int end = start + length - lag;
+
+                for (int i = start; i < end; i++)
+                {
+                    float a = source[i];
+                    float b = source[i + lag];
+                    corr += a * b;
+                    normA += a * a;
+                    normB += b * b;
+                }
+
+                if (normA <= 1e-7f || normB <= 1e-7f)
+                {
+                    continue;
+                }
+
+                float normalized = (float)(corr / Math.Sqrt(normA * normB));
+                if (normalized > best)
+                {
+                    best = normalized;
+                    bestLag = lag;
+                }
+            }
+
+            if (bestLag == 0 || best < 0.25f)
+            {
+                return 0f;
+            }
+
+            return (float)sampleRate / bestLag;
+        }
+
+        private float QuantizeFrequencyToSemitone(float frequency)
+        {
+            if (frequency <= 0f)
+            {
+                return 0f;
+            }
+
+            float midi = 69f + (12f * (float)(Math.Log(frequency / 440.0f, 2)));
+            float quantizedMidi = (float)Math.Round(midi);
+            float quantized = 440f * (float)Math.Pow(2, (quantizedMidi - 69f) / 12f);
+            return Math.Max(55f, Math.Min(1760f, quantized));
+        }
+
+        private float EstimateZeroCrossingRate(float[] source, int start, int length)
+        {
+            if (length <= 1)
+            {
+                return 0f;
+            }
+
+            int crosses = 0;
+            int end = start + length;
+            for (int i = start + 1; i < end; i++)
+            {
+                bool prevNeg = source[i - 1] < 0f;
+                bool currNeg = source[i] < 0f;
+                if (prevNeg != currNeg)
+                {
+                    crosses++;
+                }
+            }
+
+            return (float)crosses / (length - 1);
+        }
+
+        private ChipWaveType SelectChipWaveType(float zeroCrossingRate, bool voiced)
+        {
+            if (!voiced)
+            {
+                return ChipWaveType.Pulse;
+            }
+
+            if (zeroCrossingRate < 0.10f)
+            {
+                return ChipWaveType.Triangle;
+            }
+
+            if (zeroCrossingRate < 0.22f)
+            {
+                return ChipWaveType.Pulse;
+            }
+
+            return ChipWaveType.Saw;
+        }
+
+        private float GenerateChipSample(ChipWaveType wave, float phase)
+        {
+            switch (wave)
+            {
+                case ChipWaveType.Triangle:
+                    return 1f - (4f * Math.Abs(phase - 0.5f));
+                case ChipWaveType.Saw:
+                    return (2f * phase) - 1f;
+                case ChipWaveType.Pulse:
+                default:
+                    return phase < 0.35f ? 1f : -1f;
+            }
         }
     }
 }

--- a/WavConvert4Amiga/WavConvert4Amiga-Main.cs
+++ b/WavConvert4Amiga/WavConvert4Amiga-Main.cs
@@ -1300,6 +1300,12 @@ namespace WavConvert4Amiga
                             case "noisegate":
                                 result = audioEffects.ApplyNoiseGate(result, 0.04f, 0.992f);
                                 break;
+                            case "chipify_mono":
+                                result = audioEffects.ApplyChipifyMonoEffect(result, targetSampleRate);
+                                break;
+                            case "chipify_deluxe":
+                                result = audioEffects.ApplyChipifyDeluxeEffect(result, targetSampleRate);
+                                break;
                         }
                     }
                 }
@@ -2220,6 +2226,8 @@ namespace WavConvert4Amiga
                 ("Fade Out", ApplyFadeOutEffect),
                 ("Telephone BP", ApplyTelephoneBandPassEffect),
                 ("AM Radio BP", ApplyAmRadioBandPassEffect),
+                ("Chipify Mono", ApplyChipifyMonoEffect),
+                ("Chipify Deluxe", ApplyChipifyDeluxeEffect),
                 ("Reset", ResetEffects)
             };
 
@@ -2382,6 +2390,12 @@ namespace WavConvert4Amiga
                     case "noisegate":
                         currentPcmData = audioEffects.ApplyNoiseGate(currentPcmData, 0.04f, 0.992f);
                         break;
+                    case "chipify_mono":
+                        currentPcmData = audioEffects.ApplyChipifyMonoEffect(currentPcmData, targetSampleRate);
+                        break;
+                    case "chipify_deluxe":
+                        currentPcmData = audioEffects.ApplyChipifyDeluxeEffect(currentPcmData, targetSampleRate);
+                        break;
                 }
 
                 waveformViewer.SetAudioData(currentPcmData);
@@ -2502,6 +2516,16 @@ namespace WavConvert4Amiga
         private void ApplyNoiseGateEffect(object sender, EventArgs e)
         {
             ApplyTrackedEffect("noisegate", () => audioEffects.ApplyNoiseGate(currentPcmData, 0.04f, 0.992f));
+        }
+
+        private void ApplyChipifyMonoEffect(object sender, EventArgs e)
+        {
+            ApplyTrackedEffect("chipify_mono", () => audioEffects.ApplyChipifyMonoEffect(currentPcmData, GetSelectedSampleRate()));
+        }
+
+        private void ApplyChipifyDeluxeEffect(object sender, EventArgs e)
+        {
+            ApplyTrackedEffect("chipify_deluxe", () => audioEffects.ApplyChipifyDeluxeEffect(currentPcmData, GetSelectedSampleRate()));
         }
 
         private byte[] ApplySelectionEffect(Func<byte[], byte[]> effectFunction, string effectLabel)
@@ -2799,6 +2823,12 @@ namespace WavConvert4Amiga
                             break;
                         case "noisegate":
                             result = audioEffects.ApplyNoiseGate(result, 0.04f, 0.992f);
+                            break;
+                        case "chipify_mono":
+                            result = audioEffects.ApplyChipifyMonoEffect(result, targetSampleRate);
+                            break;
+                        case "chipify_deluxe":
+                            result = audioEffects.ApplyChipifyDeluxeEffect(result, targetSampleRate);
                             break;
                     }
                 }


### PR DESCRIPTION
### Motivation
- Provide chip-style resynthesis effects to generate single-note chip sounds and frame-based chipwave resynthesis for chiptune-style processing and expand the app's effect palette.

### Description
- Implemented `ApplyChipifyMonoEffect` and `ApplyChipifyDeluxeEffect` in `AudioEffectsProcessor.cs` and added a `ChipWaveType` enum and helper methods `BytesToFloats`, `EstimateFundamentalFrequency`, `QuantizeFrequencyToSemitone`, `EstimateZeroCrossingRate`, `SelectChipWaveType`, and `GenerateChipSample` to support pitch detection and synthesis.
- Integrated the two effects into the processing pipeline by adding switch cases that call the new methods in `WavConvert4Amiga-Main.cs` and added corresponding event handlers `ApplyChipifyMonoEffect` and `ApplyChipifyDeluxeEffect`.
- Added UI buttons for `Chipify Mono` and `Chipify Deluxe` within the effects panel and updated `README.md` feature list to document the new effects.

### Testing
- Ran `dotnet build` / MSBuild on the solution and the build completed successfully after the changes.
- There are no repo unit tests for these effects, so no automated test suite was executed for the new code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d83d757550832da91be42c2764ee25)