### PR TITLE
Preserve loop points across sample-rate resampling

### DIFF
--- a/WavConvert4Amiga/WavConvert4Amiga-Main.cs
+++ b/WavConvert4Amiga/WavConvert4Amiga-Main.cs
@@ -2806,6 +2806,7 @@ namespace WavConvert4Amiga
             {
                 int targetSampleRate = GetSelectedSampleRate();
                 int currentSampleRate = waveformViewer?.CurrentSampleRate ?? targetSampleRate;
+                var (oldLoopStart, oldLoopEnd) = waveformViewer.GetLoopPoints();
                 AddToListBox($"Converting to {targetSampleRate}Hz...");
 
                 // Create undo point BEFORE changing sample rate
@@ -2945,6 +2946,20 @@ namespace WavConvert4Amiga
                 // Update display
                 waveformViewer.SetAudioData(currentPcmData);
                 waveformViewer.SetSampleRate(targetSampleRate);
+
+                // Preserve existing loop selection by converting marker positions using time.
+                // This keeps the same audible region selected even when byte/sample length changes.
+                if (oldLoopStart >= 0 && oldLoopEnd > oldLoopStart)
+                {
+                    double sampleRateRatio = currentSampleRate > 0
+                        ? (double)targetSampleRate / currentSampleRate
+                        : 1.0;
+
+                    int newLoopStart = Math.Max(0, Math.Min((int)Math.Round(oldLoopStart * sampleRateRatio), Math.Max(0, currentPcmData.Length - 1)));
+                    int newLoopEnd = (int)Math.Round(oldLoopEnd * sampleRateRatio);
+                    newLoopEnd = Math.Max(newLoopStart + 1, Math.Min(newLoopEnd, currentPcmData.Length));
+                    waveformViewer.RestoreLoopPoints(newLoopStart, newLoopEnd);
+                }
 
                 AddToListBox($"Conversion to {targetSampleRate}Hz complete. Preserved {currentCutRegions.Count} cuts, {currentEffects.Count} effects");
             }


### PR DESCRIPTION
### Motivation
- Resampling changes sample counts and byte lengths which causes loop marker indices to drift or disappear, so loop selections must follow the same audio time region after conversion.

### Description
- Capture current loop markers before resampling by calling `waveformViewer.GetLoopPoints()` at the start of `ProcessSampleRateChange()`.
- After resampling and updating `currentPcmData`, map the old loop indices using a sample-rate ratio computed as `targetSampleRate / currentSampleRate` and round to the nearest sample index.
- Clamp the mapped `newLoopStart`/`newLoopEnd` to the bounds of the new buffer and restore them with `waveformViewer.RestoreLoopPoints(newLoopStart, newLoopEnd)` only when a valid loop selection existed.
- Add guards so the remapping only runs when both the start and end markers are set and the end is greater than the start.

### Testing
- Attempted to run `dotnet build WavConvert4Amiga.sln`, but the build could not be executed in this environment because `dotnet` is not installed (`dotnet: command not found`).
- No automated unit tests were executed in this environment due to the missing build toolchain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d920038744832d900b2053d7d0e626)