### PR TITLE
Add click-drag preview selection and visual highlight for loop points in WaveformViewer

### DIFF
--- a/WavConvert4Amiga/WaveformViewer.code.cs.cs
+++ b/WavConvert4Amiga/WaveformViewer.code.cs.cs
@@ -26,6 +26,10 @@ namespace WavConvert4Amiga
 
         public event EventHandler<(int start, int end)> LoopPointsChanged;
         private bool isDraggingEnd = false;
+        private bool isSelectingSecondPoint = false;
+        private bool selectionMoved = false;
+        private int selectionAnchor = -1;
+        private int previewLoopEnd = -1;
         private const int DRAG_THRESHOLD = 5;
         private const float ZOOM_STEP = 1.5f;
         private const float MAX_ZOOM = 10.0f;
@@ -220,6 +224,10 @@ namespace WavConvert4Amiga
         {
             loopStart = -1;
             loopEnd = -1;
+            selectionAnchor = -1;
+            previewLoopEnd = -1;
+            isSelectingSecondPoint = false;
+            selectionMoved = false;
             LoopPointsChanged?.Invoke(this, (-1, -1));
             Invalidate();
         }
@@ -236,6 +244,22 @@ namespace WavConvert4Amiga
             if (e.Button == MouseButtons.Right)
             {
                 ClearLoopPoints();
+                return;
+            }
+
+            if (e.Button != MouseButtons.Left)
+            {
+                return;
+            }
+
+            // If only first point exists, begin drag-selecting second point.
+            if (loopStart >= 0 && loopEnd == -1)
+            {
+                isSelectingSecondPoint = true;
+                selectionMoved = false;
+                selectionAnchor = loopStart;
+                previewLoopEnd = clickedSample;
+                Capture = true;
                 return;
             }
 
@@ -265,30 +289,41 @@ namespace WavConvert4Amiga
             }
             else if (loopEnd == -1)
             {
-                loopEnd = clickedSample;
-                if (loopEnd < loopStart)
-                {
-                    int temp = loopStart;
-                    loopStart = loopEnd;
-                    loopEnd = temp;
-                }
-                LoopPointsChanged?.Invoke(this, (loopStart, loopEnd));
+                isSelectingSecondPoint = true;
+                selectionMoved = false;
+                selectionAnchor = loopStart;
+                previewLoopEnd = clickedSample;
+                Capture = true;
             }
             else
             {
-                // Start new loop points
-                ClearLoopPoints();
+                // Start a new loop definition from this point (original click-first behavior).
                 loopStart = clickedSample;
+                loopEnd = -1;
             }
             Invalidate();
         }
         protected override void OnMouseMove(MouseEventArgs e)
         {
-            if (audioData == null || (e.Button != MouseButtons.Left)) return;
+            if (audioData == null) return;
 
             int newSample = XToSample(Math.Max(0, Math.Min(e.X, Width)));
 
-            if (isDraggingStart)
+            if (isSelectingSecondPoint)
+            {
+                if ((Control.MouseButtons & MouseButtons.Left) == 0) return;
+
+                if (newSample != previewLoopEnd)
+                {
+                    selectionMoved = true;
+                    previewLoopEnd = newSample;
+                    int previewStart = Math.Min(selectionAnchor, previewLoopEnd);
+                    int previewEnd = Math.Max(selectionAnchor, previewLoopEnd);
+                    LoopPointsChanged?.Invoke(this, (previewStart, previewEnd));
+                    Invalidate();
+                }
+            }
+            else if (isDraggingStart)
             {
                 if (newSample != loopStart && (loopEnd == -1 || newSample < loopEnd))
                 {
@@ -372,6 +407,25 @@ namespace WavConvert4Amiga
                 }
             }
 
+            int effectiveLoopEnd = isSelectingSecondPoint ? previewLoopEnd : loopEnd;
+            if (loopStart >= 0 && effectiveLoopEnd >= 0)
+            {
+                int selectionStart = Math.Min(loopStart, effectiveLoopEnd);
+                int selectionEnd = Math.Max(loopStart, effectiveLoopEnd);
+                int startX = SampleToX(selectionStart);
+                int endX = SampleToX(selectionEnd);
+                int drawStartX = Math.Max(0, Math.Min(startX, endX));
+                int drawEndX = Math.Min(Width, Math.Max(startX, endX));
+                int selectionWidth = Math.Max(0, drawEndX - drawStartX);
+                if (selectionWidth > 0)
+                {
+                    using (var selectionBrush = new SolidBrush(Color.FromArgb(60, Color.OrangeRed)))
+                    {
+                        e.Graphics.FillRectangle(selectionBrush, drawStartX, 0, selectionWidth, Height);
+                    }
+                }
+            }
+
             if (loopEnd >= 0)
             {
                 using (var pen = new Pen(Color.Red, 2))
@@ -379,6 +433,17 @@ namespace WavConvert4Amiga
                     int x = (int)((long)(loopEnd - scrollPosition) * Width / (audioData.Length / zoomFactor));
                     if (x >= 0 && x < Width)
                         e.Graphics.DrawLine(pen, x, 0, x, Height);
+                }
+            }
+            else if (isSelectingSecondPoint && previewLoopEnd >= 0)
+            {
+                using (var pen = new Pen(Color.OrangeRed, 2))
+                {
+                    int x = SampleToX(previewLoopEnd);
+                    if (x >= 0 && x < Width)
+                    {
+                        e.Graphics.DrawLine(pen, x, 0, x, Height);
+                    }
                 }
             }
 
@@ -396,6 +461,25 @@ namespace WavConvert4Amiga
 
         protected override void OnMouseUp(MouseEventArgs e)
         {
+            if (isSelectingSecondPoint && e.Button == MouseButtons.Left)
+            {
+                int releasedSample = XToSample(Math.Max(0, Math.Min(e.X, Width)));
+                previewLoopEnd = releasedSample;
+                int newStart = Math.Min(selectionAnchor, previewLoopEnd);
+                int newEnd = Math.Max(selectionAnchor, previewLoopEnd);
+
+                loopStart = newStart;
+                loopEnd = newEnd;
+                selectionAnchor = -1;
+                previewLoopEnd = -1;
+                isSelectingSecondPoint = false;
+                selectionMoved = false;
+                Capture = false;
+
+                LoopPointsChanged?.Invoke(this, (loopStart, loopEnd));
+                Invalidate();
+            }
+
             isDraggingStart = false;
             isDraggingEnd = false;
             base.OnMouseUp(e);


### PR DESCRIPTION
### Motivation
- Improve loop-point setting UX by allowing the user to click and drag to preview and pick the second loop point instead of immediately committing it.

### Description
- Added fields `isSelectingSecondPoint`, `selectionMoved`, `selectionAnchor`, and `previewLoopEnd` and updated `ClearLoopPoints` to reset selection state.
- Changed `OnMouseDown` to begin a click-drag selection preview when `loopStart` is set and `loopEnd` is unset, and to respect left-button behavior and Control-key clearing.
- Changed `OnMouseMove` to update `previewLoopEnd`, emit preview `LoopPointsChanged` events, and to support dragging the existing start/end markers as before.
- Changed `OnMouseUp` to finalize the preview into `loopStart`/`loopEnd`, clear preview state, and trigger `LoopPointsChanged`; updated `OnPaint` to draw a translucent selection rectangle and preview/marker visuals for the in-progress selection.

### Testing
- Ran `dotnet build` which completed successfully.
- Ran `dotnet test` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d925e4c894832d9d97124677db3420)