### PR TITLE
Sync sample rate dropdown with ProTracker note selection

### DIFF
--- a/WavConvert4Amiga/WavConvert4Amiga-Main.cs
+++ b/WavConvert4Amiga/WavConvert4Amiga-Main.cs
@@ -925,9 +925,12 @@ namespace WavConvert4Amiga
             if (ptNoteToHz.TryGetValue(selectedNote, out var rates))
             {
                 int hz = checkBoxNTSC.Checked ? rates.ntsc : rates.pal;
-                comboBoxSampleRate.Text = hz.ToString() + "Hz";
+                string videoStandard = checkBoxNTSC.Checked ? "NTSC" : "PAL";
+                string proTrackerLabel = $"{hz}Hz - ProTracker {selectedNote} ({videoStandard})";
+                SetSampleRateComboTextWithoutProcessing(hz, proTrackerLabel);
+                StopPreview();
                 ProcessSampleRateChange();
-                AddToListBox($"Note {selectedNote} - {(checkBoxNTSC.Checked ? "NTSC" : "PAL")} {hz}Hz");
+                AddToListBox($"Note {selectedNote} - {videoStandard} {hz}Hz");
             }
         }
 
@@ -3957,12 +3960,44 @@ namespace WavConvert4Amiga
             ProcessSampleRateChange();
         }
 
-        private void SetSampleRateComboTextWithoutProcessing(int sampleRate)
+        private void SetSampleRateComboTextWithoutProcessing(int sampleRate, string preferredLabel = null)
         {
             suppressSampleRateChangeEvents = true;
             try
             {
-                comboBoxSampleRate.Text = $"{sampleRate}Hz";
+                string fallbackLabel = $"{sampleRate}Hz";
+                string targetLabel = string.IsNullOrWhiteSpace(preferredLabel) ? fallbackLabel : preferredLabel;
+
+                int exactMatchIndex = comboBoxSampleRate.FindStringExact(targetLabel);
+                if (exactMatchIndex >= 0)
+                {
+                    comboBoxSampleRate.SelectedIndex = exactMatchIndex;
+                    return;
+                }
+
+                // Reuse an existing entry for this sample rate if one exists, even if text differs.
+                int sampleRateMatchIndex = -1;
+                for (int i = 0; i < comboBoxSampleRate.Items.Count; i++)
+                {
+                    string text = comboBoxSampleRate.Items[i]?.ToString() ?? string.Empty;
+                    string numericPrefix = new string(text.TakeWhile(char.IsDigit).ToArray());
+                    if (int.TryParse(numericPrefix, out int existingRate) && existingRate == sampleRate)
+                    {
+                        sampleRateMatchIndex = i;
+                        break;
+                    }
+                }
+
+                if (sampleRateMatchIndex >= 0)
+                {
+                    comboBoxSampleRate.Items[sampleRateMatchIndex] = targetLabel;
+                    comboBoxSampleRate.SelectedIndex = sampleRateMatchIndex;
+                }
+                else
+                {
+                    comboBoxSampleRate.Items.Add(targetLabel);
+                    comboBoxSampleRate.SelectedIndex = comboBoxSampleRate.Items.Count - 1;
+                }
             }
             finally
             {


### PR DESCRIPTION
### Motivation
- Make selecting a ProTracker (PT) note update the Sample Rate UI so the chosen PT note becomes the active sample rate and downstream operations (playback, processing, recording) use that value.
- Provide a clear, descriptive label in the Sample Rate combo (e.g. `4144Hz - ProTracker C-1 (PAL)`) so users can see the mapping.
- Ensure the update works reliably with the combo configured as a `DropDownList` and avoid unwanted re-entrancy or playback conflicts while switching rates.

### Description
- Updated `UpdateSampleRateFromNote` to compute a descriptive label (`"{hz}Hz - ProTracker {note} ({PAL|NTSC})"`), set the sample-rate combo via a helper, stop preview playback, then trigger `ProcessSampleRateChange` and log the change.
- Extended `SetSampleRateComboTextWithoutProcessing` to accept an optional `preferredLabel` and to select an exact matching item, reuse an existing item that has the same numeric sample-rate prefix (updating its text), or add a new labelled entry and select it, while suppressing change events.
- Added `StopPreview()` before processing the PT-note-driven sample-rate change and simplified the listbox message to include the chosen video standard.

### Testing
- Ran an attempted `dotnet build WavConvert4Amiga.sln`, which failed in this environment because `dotnet` is not installed (no compiled verification available).
- Changes were smoke-checked via static inspection and local code edits; no automated unit tests or CI runs were executed here due to missing SDK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d936b29380832d816a21a3c49bac06)