### PR TITLE
Add 'Save Sample' button to export edited waveform

### DIFF
--- a/WavConvert4Amiga/WavConvert4Amiga-Main.cs
+++ b/WavConvert4Amiga/WavConvert4Amiga-Main.cs
@@ -1242,6 +1242,12 @@ namespace WavConvert4Amiga
             btnSaveLoop.Click += BtnSaveLoop_Click;
             controlPanel.Controls.Add(btnSaveLoop);
 
+            Button btnSaveSample = new RetroButton();
+            btnSaveSample.Text = "Save Sample";
+            btnSaveSample.Size = buttonSize;
+            btnSaveSample.Click += BtnSaveSample_Click;
+            controlPanel.Controls.Add(btnSaveSample);
+
             // Add Preview button
             btnPreviewLoop = new RetroButton();
             btnPreviewLoop.Text = "Preview";
@@ -4673,6 +4679,82 @@ namespace WavConvert4Amiga
                 {
                     MessageBox.Show($"Error saving file: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
+            }
+        }
+
+        private void BtnSaveSample_Click(object sender, EventArgs e)
+        {
+            if (currentPcmData == null || currentPcmData.Length == 0)
+            {
+                MessageBox.Show("No waveform data available to save.", "No Audio Data", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+
+            SaveFileDialog saveDialog = new SaveFileDialog();
+            saveDialog.Filter = "WAV files (*.wav)|*.wav|8SVX files (*.8svx)|*.8svx|All files (*.*)|*.*";
+            saveDialog.FilterIndex = 1;
+
+            if (!string.IsNullOrEmpty(lastLoadedFilePath))
+            {
+                saveDialog.InitialDirectory = Path.GetDirectoryName(lastLoadedFilePath);
+                saveDialog.FileName = Path.GetFileNameWithoutExtension(lastLoadedFilePath) + "_edited.wav";
+            }
+            else
+            {
+                saveDialog.FileName = "edited_sample.wav";
+            }
+
+            if (saveDialog.ShowDialog() != DialogResult.OK)
+            {
+                return;
+            }
+
+            try
+            {
+                int sampleRate = waveformViewer?.CurrentSampleRate ?? GetSelectedSampleRate();
+                string extension = Path.GetExtension(saveDialog.FileName).ToLowerInvariant();
+
+                if (extension == ".8svx")
+                {
+                    SaveAs8SVX(currentPcmData, saveDialog.FileName, sampleRate);
+                    AddToListBox($"Saved current sample as 8SVX: {Path.GetFileName(saveDialog.FileName)}");
+                }
+                else
+                {
+                    bool use16Bit = checkBox16BitWAV.Checked;
+                    if (use16Bit)
+                    {
+                        var format = new WaveFormat(sampleRate, 16, 1);
+                        using (var writer = new WaveFileWriter(saveDialog.FileName, format))
+                        {
+                            short[] samples16Bit = new short[currentPcmData.Length];
+                            for (int i = 0; i < currentPcmData.Length; i++)
+                            {
+                                samples16Bit[i] = (short)((currentPcmData[i] - 128) * 256);
+                            }
+
+                            byte[] buffer = new byte[samples16Bit.Length * 2];
+                            Buffer.BlockCopy(samples16Bit, 0, buffer, 0, buffer.Length);
+                            writer.Write(buffer, 0, buffer.Length);
+                        }
+                        AddToListBox($"Saved current sample as 16-bit WAV: {Path.GetFileName(saveDialog.FileName)}");
+                    }
+                    else
+                    {
+                        var format = new WaveFormat(sampleRate, 8, 1);
+                        using (var writer = new WaveFileWriter(saveDialog.FileName, format))
+                        {
+                            writer.Write(currentPcmData, 0, currentPcmData.Length);
+                        }
+                        AddToListBox($"Saved current sample as 8-bit WAV: {Path.GetFileName(saveDialog.FileName)}");
+                    }
+                }
+
+                MessageBox.Show("Current sample saved successfully.", "Success", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Error saving current sample: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 


### PR DESCRIPTION
### Motivation
- Provide a one-click way to export the waveform currently shown/edited in the viewer (useful after operations like Cut or Crop-to-Loop) so users can persist the on-screen sample without reprocessing loop-only saves.

### Description
- Added a new `Save Sample` `RetroButton` to the waveform control toolbar in `WavConvert4Amiga-Main.cs` and wired it to `BtnSaveSample_Click`.
- Implemented `BtnSaveSample_Click` to export the in-memory waveform (`currentPcmData`) to disk as `.wav` (8-bit or 16-bit depending on `checkBox16BitWAV`) or `.8svx`, using `waveformViewer.CurrentSampleRate` or falling back to `GetSelectedSampleRate()`.
- When saving as 16-bit WAV the code converts 8-bit unsigned PCM to 16-bit signed PCM by scaling, and the dialog prefills a sensible filename (`<original>_edited.wav`) when a source path is known.
- Adds activity log messages via `AddToListBox` and user feedback with `MessageBox` on success or error.

### Testing
- Attempted to build the solution with `dotnet build WavConvert4Amiga.sln`, but the environment lacks `dotnet` (command not found), so the build could not be executed.
- Attempted to build with `msbuild WavConvert4Amiga.sln`, but `msbuild` is not available in the environment (command not found), so the build could not be executed.
- No automated unit tests were run in this environment due to missing build tools.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d93988a254832dbf33cffaf2a16d3f)