### PR TITLE
Add 4x4 assignable PAD window with keyboard/mouse triggering and editor recall

### DIFF
--- a/WavConvert4Amiga/SamplePadForm.cs
+++ b/WavConvert4Amiga/SamplePadForm.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Drawing;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace WavConvert4Amiga
+{
+    public class PadSlotInfo
+    {
+        public byte[] AudioData { get; set; }
+        public int SampleRate { get; set; }
+        public string Name { get; set; }
+
+        public bool HasData => AudioData != null && AudioData.Length > 0;
+    }
+
+    public class SamplePadForm : Form
+    {
+        private readonly Button[] padButtons = new Button[16];
+        private readonly char[] keyMap = "1qazxsw23edcvfr4".ToCharArray();
+        private readonly Action<int> playSlotAction;
+        private readonly Action<int> editSlotAction;
+
+        public SamplePadForm(Action<int> playSlotAction, Action<int> editSlotAction)
+        {
+            this.playSlotAction = playSlotAction;
+            this.editSlotAction = editSlotAction;
+
+            Text = "Sample PAD";
+            StartPosition = FormStartPosition.CenterParent;
+            FormBorderStyle = FormBorderStyle.SizableToolWindow;
+            MinimumSize = new Size(360, 360);
+            BackColor = Color.FromArgb(180, 190, 210);
+            KeyPreview = true;
+
+            var title = new Label
+            {
+                Text = "PAD 4x4  (Left-click: Play, Right-click: Edit in main)",
+                AutoSize = true,
+                Location = new Point(12, 12),
+                ForeColor = Color.Black
+            };
+            Controls.Add(title);
+
+            var table = new TableLayoutPanel
+            {
+                Location = new Point(12, 36),
+                Size = new Size(320, 280),
+                ColumnCount = 4,
+                RowCount = 4,
+                Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right,
+                BackColor = Color.FromArgb(140, 150, 170),
+                Padding = new Padding(4)
+            };
+
+            for (int i = 0; i < 4; i++)
+            {
+                table.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 25f));
+                table.RowStyles.Add(new RowStyle(SizeType.Percent, 25f));
+            }
+
+            for (int slot = 0; slot < 16; slot++)
+            {
+                int capturedSlot = slot;
+                var button = new RetroButton
+                {
+                    Dock = DockStyle.Fill,
+                    Margin = new Padding(4),
+                    Text = GetDefaultSlotLabel(slot),
+                    Tag = slot
+                };
+
+                button.MouseDown += (s, e) =>
+                {
+                    if (e.Button == MouseButtons.Right)
+                    {
+                        editSlotAction?.Invoke(capturedSlot);
+                        return;
+                    }
+
+                    if (e.Button == MouseButtons.Left)
+                    {
+                        TriggerSlot(capturedSlot);
+                    }
+                };
+
+                padButtons[slot] = button;
+                table.Controls.Add(button, slot % 4, slot / 4);
+            }
+
+            Controls.Add(table);
+            Resize += (s, e) =>
+            {
+                table.Size = new Size(ClientSize.Width - 24, ClientSize.Height - 48);
+            };
+
+            KeyDown += SamplePadForm_KeyDown;
+        }
+
+        public void RefreshSlots(PadSlotInfo[] slots)
+        {
+            for (int i = 0; i < padButtons.Length; i++)
+            {
+                var slot = slots != null && i < slots.Length ? slots[i] : null;
+                bool hasData = slot != null && slot.HasData;
+                string name = hasData ? (slot.Name ?? "Sample") : "(empty)";
+                string keyLabel = char.ToUpperInvariant(keyMap[i]).ToString();
+
+                padButtons[i].Text = $"{i + 1} [{keyLabel}]\n{name}";
+                padButtons[i].BackColor = hasData ? Color.FromArgb(210, 220, 240) : Color.FromArgb(185, 190, 205);
+                padButtons[i].Enabled = true;
+            }
+        }
+
+        private void SamplePadForm_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Control || e.Alt)
+            {
+                return;
+            }
+
+            char keyChar = GetKeyChar(e.KeyCode);
+            int slot = Array.FindIndex(keyMap, k => k == keyChar);
+            if (slot >= 0)
+            {
+                TriggerSlot(slot);
+                e.Handled = true;
+            }
+        }
+
+        private static char GetKeyChar(Keys key)
+        {
+            string text = key.ToString();
+            if (text.StartsWith("D") && text.Length == 2 && char.IsDigit(text[1]))
+            {
+                return char.ToLowerInvariant(text[1]);
+            }
+
+            if (text.Length == 1 && char.IsLetterOrDigit(text[0]))
+            {
+                return char.ToLowerInvariant(text[0]);
+            }
+
+            return '\0';
+        }
+
+        private void TriggerSlot(int slot)
+        {
+            playSlotAction?.Invoke(slot);
+        }
+
+        private string GetDefaultSlotLabel(int slot)
+        {
+            string keyLabel = char.ToUpperInvariant(keyMap[slot]).ToString();
+            return $"{slot + 1} [{keyLabel}]\n(empty)";
+        }
+    }
+}

--- a/WavConvert4Amiga/WavConvert4Amiga-Main.cs
+++ b/WavConvert4Amiga/WavConvert4Amiga-Main.cs
@@ -99,7 +99,9 @@ namespace WavConvert4Amiga
         private bool suppressSampleRateChangeEvents = false;
         private (double startSeconds, double endSeconds)? cropSelectionSeconds = null;
         private CheckBox checkBoxPianoMode;
+        private CheckBox checkBoxShowPad;
         private Panel pianoPanel;
+        private Button btnPadAssign;
         private readonly Dictionary<Keys, int> pianoKeyOffsets = new Dictionary<Keys, int>
         {
             { Keys.Z, 0 }, { Keys.S, 1 }, { Keys.X, 2 }, { Keys.D, 3 }, { Keys.C, 4 }, { Keys.V, 5 },
@@ -111,6 +113,11 @@ namespace WavConvert4Amiga
         private WaveOutEvent pianoWaveOut;
         private MemoryStream pianoAudioStream;
         private RawSourceWaveStream pianoWaveStream;
+        private WaveOutEvent padWaveOut;
+        private MemoryStream padAudioStream;
+        private RawSourceWaveStream padWaveStream;
+        private readonly PadSlotInfo[] padSlots = Enumerable.Range(0, 16).Select(_ => new PadSlotInfo()).ToArray();
+        private SamplePadForm samplePadForm;
 
 
         private Dictionary<string, (int pal, int ntsc)> ptNoteToHz = new Dictionary<string, (int pal, int ntsc)>()
@@ -357,6 +364,10 @@ namespace WavConvert4Amiga
                 if (checkBoxPianoMode != null)
                 {
                     checkBoxPianoMode.Location = new Point(checkBoxNTSC.Right + 16, row1Y + 3);
+                }
+                if (checkBoxShowPad != null)
+                {
+                    checkBoxShowPad.Location = new Point(checkBoxPianoMode.Right + 16, row1Y + 3);
                 }
 
                 int rightX = ClientSize.Width - margin;
@@ -677,6 +688,13 @@ namespace WavConvert4Amiga
             StyleCheckbox(checkBoxPianoMode);
             checkBoxPianoMode.CheckedChanged += (s, e) => pianoPanel?.Invalidate();
 
+            checkBoxShowPad = new CheckBox();
+            checkBoxShowPad.Text = "Show PAD";
+            checkBoxShowPad.Location = new Point(checkBoxPianoMode.Right + 20, comboBoxPTNote.Top + 2);
+            checkBoxShowPad.AutoSize = true;
+            StyleCheckbox(checkBoxShowPad);
+            checkBoxShowPad.CheckedChanged += CheckBoxShowPad_CheckedChanged;
+
             // Handle selection change
             comboBoxPTNote.SelectedIndexChanged += ComboBoxPTNote_SelectedIndexChanged;
             comboBoxPTNote.KeyDown += ComboBoxPTNote_KeyDown;
@@ -695,6 +713,7 @@ namespace WavConvert4Amiga
             this.Controls.Add(comboBoxPTNote);
             this.Controls.Add(checkBoxNTSC);
             this.Controls.Add(checkBoxPianoMode);
+            this.Controls.Add(checkBoxShowPad);
         }
 
         private void InitializePianoPanel()
@@ -890,6 +909,178 @@ namespace WavConvert4Amiga
                 activePianoOffset = -1;
                 pianoPanel?.Invalidate();
             }
+        }
+
+        private void BtnPadAssign_Click(object sender, EventArgs e)
+        {
+            if (currentPcmData == null || currentPcmData.Length == 0)
+            {
+                MessageBox.Show("Load or record a sample first, then assign it to a PAD slot.", "No Sample Loaded",
+                    MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return;
+            }
+
+            var menu = new ContextMenuStrip();
+            menu.Closed += (s, args) => menu.Dispose();
+            for (int i = 0; i < 16; i++)
+            {
+                int slot = i;
+                string slotLabel = $"Slot {slot + 1}";
+                if (padSlots[slot].HasData && !string.IsNullOrWhiteSpace(padSlots[slot].Name))
+                {
+                    slotLabel += $" ({padSlots[slot].Name})";
+                }
+
+                var item = new ToolStripMenuItem(slotLabel);
+                item.Click += (s, args) => AssignCurrentSampleToPadSlot(slot);
+                menu.Items.Add(item);
+            }
+
+            var button = sender as Control;
+            Point menuPoint = button != null
+                ? button.PointToScreen(new Point(0, button.Height))
+                : Cursor.Position;
+            menu.Show(menuPoint);
+        }
+
+        private void AssignCurrentSampleToPadSlot(int slot)
+        {
+            if (slot < 0 || slot >= padSlots.Length || currentPcmData == null || currentPcmData.Length == 0)
+            {
+                return;
+            }
+
+            byte[] copiedAudio = new byte[currentPcmData.Length];
+            Array.Copy(currentPcmData, copiedAudio, currentPcmData.Length);
+
+            int sampleRate = GetSelectedSampleRate();
+            string sourceName = !string.IsNullOrWhiteSpace(lastLoadedFilePath)
+                ? Path.GetFileNameWithoutExtension(lastLoadedFilePath)
+                : $"Sample {slot + 1}";
+
+            padSlots[slot].AudioData = copiedAudio;
+            padSlots[slot].SampleRate = sampleRate;
+            padSlots[slot].Name = sourceName;
+
+            AddToListBox($"PAD: Assigned current sample to slot {slot + 1} ({sampleRate}Hz).");
+            samplePadForm?.RefreshSlots(padSlots);
+        }
+
+        private void CheckBoxShowPad_CheckedChanged(object sender, EventArgs e)
+        {
+            if (checkBoxShowPad == null)
+            {
+                return;
+            }
+
+            if (checkBoxShowPad.Checked)
+            {
+                EnsureSamplePadWindow();
+                samplePadForm?.Show(this);
+                samplePadForm?.BringToFront();
+            }
+            else
+            {
+                samplePadForm?.Hide();
+            }
+        }
+
+        private void EnsureSamplePadWindow()
+        {
+            if (samplePadForm != null && !samplePadForm.IsDisposed)
+            {
+                samplePadForm.RefreshSlots(padSlots);
+                return;
+            }
+
+            samplePadForm = new SamplePadForm(PlayPadSlot, EditPadSlotInMain);
+            samplePadForm.FormClosed += (s, e) =>
+            {
+                if (checkBoxShowPad != null && !checkBoxShowPad.IsDisposed)
+                {
+                    checkBoxShowPad.Checked = false;
+                }
+            };
+            samplePadForm.RefreshSlots(padSlots);
+        }
+
+        private void PlayPadSlot(int slot)
+        {
+            if (slot < 0 || slot >= padSlots.Length)
+            {
+                return;
+            }
+
+            var slotInfo = padSlots[slot];
+            if (slotInfo == null || !slotInfo.HasData)
+            {
+                return;
+            }
+
+            try
+            {
+                lock (playbackLock)
+                {
+                    padWaveOut?.Stop();
+                    padWaveOut?.Dispose();
+                    padWaveOut = new WaveOutEvent
+                    {
+                        DesiredLatency = 90,
+                        NumberOfBuffers = 3
+                    };
+
+                    padWaveStream?.Dispose();
+                    padWaveStream = null;
+
+                    padAudioStream?.Dispose();
+                    padAudioStream = null;
+
+                    padAudioStream = new MemoryStream(slotInfo.AudioData, false);
+                    padWaveStream = new RawSourceWaveStream(padAudioStream, new WaveFormat(slotInfo.SampleRate, 8, 1));
+                    padWaveOut.Init(padWaveStream);
+                    padWaveOut.Play();
+                }
+            }
+            catch
+            {
+                // keep pad playback resilient without interrupting editing workflow
+            }
+        }
+
+        private void EditPadSlotInMain(int slot)
+        {
+            if (slot < 0 || slot >= padSlots.Length)
+            {
+                return;
+            }
+
+            var slotInfo = padSlots[slot];
+            if (slotInfo == null || !slotInfo.HasData)
+            {
+                MessageBox.Show("That PAD slot is empty.", "PAD", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return;
+            }
+
+            StopPreview();
+            ClearAllState();
+
+            currentPcmData = new byte[slotInfo.AudioData.Length];
+            Array.Copy(slotInfo.AudioData, currentPcmData, slotInfo.AudioData.Length);
+
+            originalPcmData = new byte[slotInfo.AudioData.Length];
+            Array.Copy(slotInfo.AudioData, originalPcmData, slotInfo.AudioData.Length);
+
+            originalSampleRate = slotInfo.SampleRate;
+            originalFormat = new WaveFormat(slotInfo.SampleRate, 8, 1);
+            isRecorded = true;
+            lastLoadedFilePath = null;
+
+            SetSampleRateComboTextWithoutProcessing(slotInfo.SampleRate, $"{slotInfo.SampleRate}Hz - PAD Slot {slot + 1}");
+
+            waveformViewer?.SetAudioData(currentPcmData);
+            waveformViewer?.Invalidate();
+            StoreInitialState();
+            AddToListBox($"PAD: Loaded slot {slot + 1} into editor.");
         }
 
         private void ComboBoxPTNote_DrawItem(object sender, DrawItemEventArgs e)
@@ -1257,6 +1448,12 @@ namespace WavConvert4Amiga
             btnPreviewLoop.Size = buttonSize;
             btnPreviewLoop.Click += BtnPreviewLoop_Click;
             controlPanel.Controls.Add(btnPreviewLoop);
+
+            btnPadAssign = new RetroButton();
+            btnPadAssign.Text = "PAD";
+            btnPadAssign.Size = buttonSize;
+            btnPadAssign.Click += BtnPadAssign_Click;
+            controlPanel.Controls.Add(btnPadAssign);
 
             // Initialize the waveform viewer AFTER the control panel
             waveformViewer = new WaveformViewer();
@@ -4805,6 +5002,11 @@ namespace WavConvert4Amiga
             pianoWaveOut?.Dispose();
             pianoWaveStream?.Dispose();
             pianoAudioStream?.Dispose();
+            padWaveOut?.Stop();
+            padWaveOut?.Dispose();
+            padWaveStream?.Dispose();
+            padAudioStream?.Dispose();
+            samplePadForm?.Close();
         }
 
         private void ApplyAmigaStyle(Control.ControlCollection controls)

--- a/WavConvert4Amiga/WavConvert4Amiga.csproj
+++ b/WavConvert4Amiga/WavConvert4Amiga.csproj
@@ -159,6 +159,7 @@
     <Compile Include="RetroButton.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="SamplePadForm.cs" />
     <Compile Include="WaveformProcessor.cs" />
     <Compile Include="WaveformViewer.code.cs.cs">
       <SubType>UserControl</SubType>


### PR DESCRIPTION
### Motivation
- Provide a simple 4x4 pad interface (Novation-pad style) so users can assign prepared samples into slots and trigger them quickly from a compact UI.
- Allow quick auditioning via keyboard or mouse and a convenient way to edit a pad slot back into the main editor for further processing.

### Description
- Added a new UI form `SamplePadForm.cs` implementing a 4x4 pad grid with keyboard mapping `1qazxsw23edcvfr4`, left-click play, and right-click "edit back in main" behavior via `PlayPadSlot` and `EditPadSlotInMain` callbacks.
- Integrated PAD controls into the main form by adding a `PAD` assignment button and a `Show PAD` checkbox, slot storage (`PadSlotInfo[] padSlots`), playback plumbing (`padWaveOut`, `padAudioStream`, `padWaveStream`), and slot assignment logic (`AssignCurrentSampleToPadSlot`).
- When loading a slot into the editor the code rehydrates `currentPcmData`, `originalPcmData`, `originalFormat`, sets the UI sample-rate label via `SetSampleRateComboTextWithoutProcessing`, updates the waveform viewer, and calls `StoreInitialState` to seed undo state.
- Updated project file to include the new `SamplePadForm.cs` compile entry (`WavConvert4Amiga.csproj`).

### Testing
- Attempted to build the solution with `msbuild WavConvert4Amiga.sln /t:Build /p:Configuration=Debug`, but `msbuild` is not available in the environment, so a full build could not be run.
- Attempted to build with `dotnet build WavConvert4Amiga.sln -c Debug`, but `dotnet` is not available in the environment, so the build could not be executed.
- No automated unit tests were present or executed in this environment; runtime validation should be performed on a Windows dev machine with the .NET tooling installed to verify playback and editor recall behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9672d2e08832d8454c9f1f4636715)