### PR TITLE
Add 4x4 Sample PAD UI and pad playback/assignment integration

### DIFF
--- a/WavConvert4Amiga/SamplePadForm.cs
+++ b/WavConvert4Amiga/SamplePadForm.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Drawing;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace WavConvert4Amiga
+{
+    public class PadSlotInfo
+    {
+        public byte[] AudioData { get; set; }
+        public int SampleRate { get; set; }
+        public string Name { get; set; }
+
+        public bool HasData => AudioData != null && AudioData.Length > 0;
+    }
+
+    public class SamplePadForm : Form
+    {
+        private readonly Button[] padButtons = new Button[16];
+        private readonly char[] keyMap = "1qazxsw23edcvfr4".ToCharArray();
+        private readonly Action<int> playSlotAction;
+        private readonly Action<int> editSlotAction;
+        private readonly Action stopAllAction;
+        private readonly bool[] loadedSlots = new bool[16];
+        private readonly bool[] playingSlots = new bool[16];
+
+        public SamplePadForm(Action<int> playSlotAction, Action<int> editSlotAction, Action stopAllAction)
+        {
+            this.playSlotAction = playSlotAction;
+            this.editSlotAction = editSlotAction;
+            this.stopAllAction = stopAllAction;
+
+            Text = "Sample PAD";
+            StartPosition = FormStartPosition.CenterParent;
+            FormBorderStyle = FormBorderStyle.SizableToolWindow;
+            MinimumSize = new Size(360, 360);
+            BackColor = Color.FromArgb(180, 190, 210);
+            KeyPreview = true;
+
+            var title = new Label
+            {
+                Text = "PAD 4x4  (Left-click: Play, Right-click: Edit in main)",
+                AutoSize = true,
+                Location = new Point(12, 12),
+                ForeColor = Color.Black
+            };
+            Controls.Add(title);
+
+            var stopAllButton = new RetroButton
+            {
+                Text = "Stop All",
+                Size = new Size(90, 24),
+                Location = new Point(240, 8),
+                Anchor = AnchorStyles.Top | AnchorStyles.Right
+            };
+            stopAllButton.Click += (s, e) => stopAllAction?.Invoke();
+            Controls.Add(stopAllButton);
+
+            var table = new TableLayoutPanel
+            {
+                Location = new Point(12, 36),
+                Size = new Size(320, 280),
+                ColumnCount = 4,
+                RowCount = 4,
+                Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right,
+                BackColor = Color.FromArgb(140, 150, 170),
+                Padding = new Padding(4)
+            };
+
+            for (int i = 0; i < 4; i++)
+            {
+                table.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 25f));
+                table.RowStyles.Add(new RowStyle(SizeType.Percent, 25f));
+            }
+
+            for (int slot = 0; slot < 16; slot++)
+            {
+                int capturedSlot = slot;
+                var button = new RetroButton
+                {
+                    Dock = DockStyle.Fill,
+                    Margin = new Padding(4),
+                    Text = GetDefaultSlotLabel(slot),
+                    Tag = slot
+                };
+
+                button.MouseDown += (s, e) =>
+                {
+                    if (e.Button == MouseButtons.Right)
+                    {
+                        editSlotAction?.Invoke(capturedSlot);
+                        return;
+                    }
+
+                    if (e.Button == MouseButtons.Left)
+                    {
+                        TriggerSlot(capturedSlot);
+                    }
+                };
+
+                padButtons[slot] = button;
+                table.Controls.Add(button, slot % 4, slot / 4);
+            }
+
+            Controls.Add(table);
+            Resize += (s, e) =>
+            {
+                table.Size = new Size(ClientSize.Width - 24, ClientSize.Height - 48);
+            };
+
+            KeyDown += SamplePadForm_KeyDown;
+        }
+
+        public void RefreshSlots(PadSlotInfo[] slots)
+        {
+            for (int i = 0; i < padButtons.Length; i++)
+            {
+                var slot = slots != null && i < slots.Length ? slots[i] : null;
+                bool hasData = slot != null && slot.HasData;
+                loadedSlots[i] = hasData;
+                string name = hasData ? (slot.Name ?? "Sample") : "(empty)";
+                string keyLabel = char.ToUpperInvariant(keyMap[i]).ToString();
+
+                padButtons[i].Text = $"{i + 1} [{keyLabel}]\n{name}";
+                ApplyPadVisual(i);
+            }
+        }
+
+        public void SetPadPlaying(int slot, bool isPlaying)
+        {
+            if (slot < 0 || slot >= padButtons.Length)
+            {
+                return;
+            }
+
+            playingSlots[slot] = isPlaying;
+            ApplyPadVisual(slot);
+        }
+
+        private void SamplePadForm_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Control || e.Alt)
+            {
+                return;
+            }
+
+            char keyChar = GetKeyChar(e.KeyCode);
+            int slot = Array.FindIndex(keyMap, k => k == keyChar);
+            if (slot >= 0)
+            {
+                TriggerSlot(slot);
+                e.Handled = true;
+            }
+        }
+
+        private static char GetKeyChar(Keys key)
+        {
+            string text = key.ToString();
+            if (text.StartsWith("D") && text.Length == 2 && char.IsDigit(text[1]))
+            {
+                return char.ToLowerInvariant(text[1]);
+            }
+
+            if (text.Length == 1 && char.IsLetterOrDigit(text[0]))
+            {
+                return char.ToLowerInvariant(text[0]);
+            }
+
+            return '\0';
+        }
+
+        private void TriggerSlot(int slot)
+        {
+            playSlotAction?.Invoke(slot);
+        }
+
+        private void ApplyPadVisual(int slot)
+        {
+            bool hasData = loadedSlots[slot];
+            bool isPlaying = playingSlots[slot];
+            var button = padButtons[slot];
+
+            button.Enabled = hasData;
+
+            if (!hasData)
+            {
+                button.BackColor = Color.FromArgb(140, 145, 160);
+                button.ForeColor = Color.FromArgb(90, 95, 110);
+                return;
+            }
+
+            button.ForeColor = Color.Black;
+            button.BackColor = isPlaying ? Color.FromArgb(255, 215, 0) : Color.FromArgb(210, 220, 240);
+        }
+
+        private string GetDefaultSlotLabel(int slot)
+        {
+            string keyLabel = char.ToUpperInvariant(keyMap[slot]).ToString();
+            return $"{slot + 1} [{keyLabel}]\n(empty)";
+        }
+    }
+}

--- a/WavConvert4Amiga/WavConvert4Amiga-Main.cs
+++ b/WavConvert4Amiga/WavConvert4Amiga-Main.cs
@@ -99,7 +99,13 @@ namespace WavConvert4Amiga
         private bool suppressSampleRateChangeEvents = false;
         private (double startSeconds, double endSeconds)? cropSelectionSeconds = null;
         private CheckBox checkBoxPianoMode;
+        private CheckBox checkBoxShowPad;
         private Panel pianoPanel;
+        private Button btnPadAssign;
+        private Button btnBackToMasterSample;
+        private Button btnStopAllAudio;
+        private FlowLayoutPanel waveformControlPanel;
+        private ContextMenuStrip padAssignContextMenu;
         private readonly Dictionary<Keys, int> pianoKeyOffsets = new Dictionary<Keys, int>
         {
             { Keys.Z, 0 }, { Keys.S, 1 }, { Keys.X, 2 }, { Keys.D, 3 }, { Keys.C, 4 }, { Keys.V, 5 },
@@ -111,6 +117,20 @@ namespace WavConvert4Amiga
         private WaveOutEvent pianoWaveOut;
         private MemoryStream pianoAudioStream;
         private RawSourceWaveStream pianoWaveStream;
+        private sealed class PadPlaybackVoice
+        {
+            public WaveOutEvent Output;
+            public MemoryStream AudioStream;
+            public RawSourceWaveStream WaveStream;
+        }
+        private readonly List<PadPlaybackVoice> activePadVoices = new List<PadPlaybackVoice>();
+        private readonly int[] activePadPlayCounts = new int[16];
+        private readonly PadSlotInfo[] padSlots = Enumerable.Range(0, 16).Select(_ => new PadSlotInfo()).ToArray();
+        private SamplePadForm samplePadForm;
+        private byte[] masterPcmBackup;
+        private byte[] masterOriginalPcmBackup;
+        private int masterOriginalSampleRate;
+        private bool hasMasterBackup = false;
 
 
         private Dictionary<string, (int pal, int ntsc)> ptNoteToHz = new Dictionary<string, (int pal, int ntsc)>()
@@ -282,6 +302,12 @@ namespace WavConvert4Amiga
             }
 
             this.Resize += HandleResponsiveLayoutResize;
+            this.Shown += (s, e) =>
+            {
+                LayoutMainFormControls();
+                waveformControlPanel?.PerformLayout();
+                panelWaveform?.PerformLayout();
+            };
         }
 
         private void MainForm_Load(object sender, EventArgs e)
@@ -374,6 +400,16 @@ namespace WavConvert4Amiga
                 placeRight(checkBoxLowPass, row1Y + 3);
                 placeRight(checkBoxEnable8SVX, row1Y + 3);
                 placeRight(checkBox16BitWAV, row1Y + 3);
+                placeRight(checkBoxShowPad, row1Y + 3);
+
+                int leftClusterRight = checkBoxPianoMode != null ? checkBoxPianoMode.Right : checkBoxNTSC.Right;
+                if (checkBoxShowPad != null && checkBoxShowPad.Left < leftClusterRight + gap)
+                {
+                    int width = checkBoxShowPad.PreferredSize.Width;
+                    checkBoxShowPad.Location = new Point(
+                        Math.Max(margin, ClientSize.Width - margin - width),
+                        row2Y + 5);
+                }
 
                 const int queueButtonHeight = 30;
                 const int queueButtonCount = 5;
@@ -677,6 +713,13 @@ namespace WavConvert4Amiga
             StyleCheckbox(checkBoxPianoMode);
             checkBoxPianoMode.CheckedChanged += (s, e) => pianoPanel?.Invalidate();
 
+            checkBoxShowPad = new CheckBox();
+            checkBoxShowPad.Text = "Show PAD";
+            checkBoxShowPad.Location = new Point(checkBoxPianoMode.Right + 20, comboBoxPTNote.Top + 2);
+            checkBoxShowPad.AutoSize = true;
+            StyleCheckbox(checkBoxShowPad);
+            checkBoxShowPad.CheckedChanged += CheckBoxShowPad_CheckedChanged;
+
             // Handle selection change
             comboBoxPTNote.SelectedIndexChanged += ComboBoxPTNote_SelectedIndexChanged;
             comboBoxPTNote.KeyDown += ComboBoxPTNote_KeyDown;
@@ -695,6 +738,7 @@ namespace WavConvert4Amiga
             this.Controls.Add(comboBoxPTNote);
             this.Controls.Add(checkBoxNTSC);
             this.Controls.Add(checkBoxPianoMode);
+            this.Controls.Add(checkBoxShowPad);
         }
 
         private void InitializePianoPanel()
@@ -890,6 +934,342 @@ namespace WavConvert4Amiga
                 activePianoOffset = -1;
                 pianoPanel?.Invalidate();
             }
+        }
+
+        private void BtnPadAssign_Click(object sender, EventArgs e)
+        {
+            if (currentPcmData == null || currentPcmData.Length == 0)
+            {
+                MessageBox.Show("Load or record a sample first, then assign it to a PAD slot.", "No Sample Loaded",
+                    MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return;
+            }
+
+            if (padAssignContextMenu == null || padAssignContextMenu.IsDisposed)
+            {
+                padAssignContextMenu = new ContextMenuStrip();
+            }
+
+            padAssignContextMenu.Items.Clear();
+            for (int i = 0; i < 16; i++)
+            {
+                int slot = i;
+                string slotLabel = $"Slot {slot + 1}";
+                if (padSlots[slot].HasData && !string.IsNullOrWhiteSpace(padSlots[slot].Name))
+                {
+                    slotLabel += $" ({padSlots[slot].Name})";
+                }
+
+                var item = new ToolStripMenuItem(slotLabel);
+                item.Click += (s, args) => AssignCurrentSampleToPadSlot(slot);
+                padAssignContextMenu.Items.Add(item);
+            }
+
+            var button = sender as Control;
+            Point menuPoint = button != null
+                ? button.PointToScreen(new Point(0, button.Height))
+                : Cursor.Position;
+            padAssignContextMenu.Show(menuPoint);
+        }
+
+        private void AssignCurrentSampleToPadSlot(int slot)
+        {
+            if (slot < 0 || slot >= padSlots.Length || currentPcmData == null || currentPcmData.Length == 0)
+            {
+                return;
+            }
+
+            byte[] copiedAudio = new byte[currentPcmData.Length];
+            Array.Copy(currentPcmData, copiedAudio, currentPcmData.Length);
+
+            int sampleRate = GetSelectedSampleRate();
+            string sourceName = !string.IsNullOrWhiteSpace(lastLoadedFilePath)
+                ? Path.GetFileNameWithoutExtension(lastLoadedFilePath)
+                : $"Sample {slot + 1}";
+
+            padSlots[slot].AudioData = copiedAudio;
+            padSlots[slot].SampleRate = sampleRate;
+            padSlots[slot].Name = sourceName;
+
+            AddToListBox($"PAD: Assigned current sample to slot {slot + 1} ({sampleRate}Hz).");
+            samplePadForm?.RefreshSlots(padSlots);
+        }
+
+        private void CheckBoxShowPad_CheckedChanged(object sender, EventArgs e)
+        {
+            if (checkBoxShowPad == null)
+            {
+                return;
+            }
+
+            if (checkBoxShowPad.Checked)
+            {
+                EnsureSamplePadWindow();
+                samplePadForm?.Show(this);
+                samplePadForm?.BringToFront();
+            }
+            else
+            {
+                samplePadForm?.Hide();
+            }
+        }
+
+        private void EnsureSamplePadWindow()
+        {
+            if (samplePadForm != null && !samplePadForm.IsDisposed)
+            {
+                samplePadForm.RefreshSlots(padSlots);
+                return;
+            }
+
+            samplePadForm = new SamplePadForm(PlayPadSlot, EditPadSlotInMain, StopAllInteractiveAudio);
+            samplePadForm.FormClosed += (s, e) =>
+            {
+                if (checkBoxShowPad != null && !checkBoxShowPad.IsDisposed)
+                {
+                    checkBoxShowPad.Checked = false;
+                }
+            };
+            samplePadForm.RefreshSlots(padSlots);
+            for (int i = 0; i < activePadPlayCounts.Length; i++)
+            {
+                samplePadForm.SetPadPlaying(i, activePadPlayCounts[i] > 0);
+            }
+        }
+
+        private void PlayPadSlot(int slot)
+        {
+            if (slot < 0 || slot >= padSlots.Length)
+            {
+                return;
+            }
+
+            var slotInfo = padSlots[slot];
+            if (slotInfo == null || !slotInfo.HasData)
+            {
+                return;
+            }
+
+            try
+            {
+                lock (playbackLock)
+                {
+                    var voice = new PadPlaybackVoice
+                    {
+                        Output = new WaveOutEvent
+                        {
+                            DesiredLatency = 90,
+                            NumberOfBuffers = 3
+                        }
+                    };
+
+                    voice.AudioStream = new MemoryStream(slotInfo.AudioData, false);
+                    voice.WaveStream = new RawSourceWaveStream(voice.AudioStream, new WaveFormat(slotInfo.SampleRate, 8, 1));
+                    voice.Output.Init(voice.WaveStream);
+                    voice.Output.PlaybackStopped += (s, e) =>
+                    {
+                        lock (playbackLock)
+                        {
+                            activePadVoices.Remove(voice);
+                            activePadPlayCounts[slot] = Math.Max(0, activePadPlayCounts[slot] - 1);
+                        }
+                        try { voice.Output.Dispose(); } catch { }
+                        try { voice.WaveStream.Dispose(); } catch { }
+                        try { voice.AudioStream.Dispose(); } catch { }
+                        UpdatePadPlayingState(slot);
+                    };
+
+                    activePadVoices.Add(voice);
+                    activePadPlayCounts[slot]++;
+                    UpdatePadPlayingState(slot);
+                    if (activePadVoices.Count > 24)
+                    {
+                        StopAndDisposePadVoice(activePadVoices[0], true);
+                        activePadVoices.RemoveAt(0);
+                    }
+
+                    voice.Output.Play();
+                }
+            }
+            catch
+            {
+                // keep pad playback resilient without interrupting editing workflow
+            }
+        }
+
+        private void StopAndDisposePadVoice(PadPlaybackVoice voice, bool resetPadIndicators = false)
+        {
+            if (voice == null)
+            {
+                return;
+            }
+
+            try { voice.Output?.Stop(); } catch { }
+            try { voice.Output?.Dispose(); } catch { }
+            try { voice.WaveStream?.Dispose(); } catch { }
+            try { voice.AudioStream?.Dispose(); } catch { }
+
+            if (resetPadIndicators)
+            {
+                for (int i = 0; i < activePadPlayCounts.Length; i++)
+                {
+                    activePadPlayCounts[i] = 0;
+                    UpdatePadPlayingState(i);
+                }
+            }
+        }
+
+        private void EditPadSlotInMain(int slot)
+        {
+            if (slot < 0 || slot >= padSlots.Length)
+            {
+                return;
+            }
+
+            var slotInfo = padSlots[slot];
+            if (slotInfo == null || !slotInfo.HasData)
+            {
+                MessageBox.Show("That PAD slot is empty.", "PAD", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return;
+            }
+
+            SaveMasterSampleBackup();
+            StopPreview();
+            ClearAllState();
+
+            currentPcmData = new byte[slotInfo.AudioData.Length];
+            Array.Copy(slotInfo.AudioData, currentPcmData, slotInfo.AudioData.Length);
+
+            originalPcmData = new byte[slotInfo.AudioData.Length];
+            Array.Copy(slotInfo.AudioData, originalPcmData, slotInfo.AudioData.Length);
+
+            originalSampleRate = slotInfo.SampleRate;
+            originalFormat = new WaveFormat(slotInfo.SampleRate, 8, 1);
+            isRecorded = true;
+            lastLoadedFilePath = null;
+
+            SetSampleRateComboTextWithoutProcessing(slotInfo.SampleRate, $"{slotInfo.SampleRate}Hz - PAD Slot {slot + 1}");
+
+            waveformViewer?.SetAudioData(currentPcmData);
+            waveformViewer?.Invalidate();
+            StoreInitialState();
+            btnBackToMasterSample.Enabled = hasMasterBackup;
+            AddToListBox($"PAD: Loaded slot {slot + 1} into editor.");
+        }
+
+        private void SaveMasterSampleBackup()
+        {
+            if (currentPcmData == null || currentPcmData.Length == 0)
+            {
+                return;
+            }
+
+            masterPcmBackup = new byte[currentPcmData.Length];
+            Array.Copy(currentPcmData, masterPcmBackup, currentPcmData.Length);
+
+            byte[] sourceOriginal = (originalPcmData != null && originalPcmData.Length > 0) ? originalPcmData : currentPcmData;
+            masterOriginalPcmBackup = new byte[sourceOriginal.Length];
+            Array.Copy(sourceOriginal, masterOriginalPcmBackup, sourceOriginal.Length);
+            masterOriginalSampleRate = originalFormat?.SampleRate ?? GetSelectedSampleRate();
+            hasMasterBackup = true;
+        }
+
+        private void ClearMasterSampleBackup()
+        {
+            hasMasterBackup = false;
+            masterPcmBackup = null;
+            masterOriginalPcmBackup = null;
+            masterOriginalSampleRate = 0;
+            if (btnBackToMasterSample != null)
+            {
+                btnBackToMasterSample.Enabled = false;
+            }
+        }
+
+        private void BtnBackToMasterSample_Click(object sender, EventArgs e)
+        {
+            RestoreMasterSampleBackup();
+        }
+
+        private void RestoreMasterSampleBackup()
+        {
+            if (!hasMasterBackup || masterPcmBackup == null || masterPcmBackup.Length == 0 || masterOriginalPcmBackup == null || masterOriginalPcmBackup.Length == 0)
+            {
+                MessageBox.Show("No master sample backup is available yet.", "Back to Master", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return;
+            }
+
+            StopPreview();
+            ClearAllState();
+
+            currentPcmData = new byte[masterPcmBackup.Length];
+            Array.Copy(masterPcmBackup, currentPcmData, masterPcmBackup.Length);
+
+            originalPcmData = new byte[masterOriginalPcmBackup.Length];
+            Array.Copy(masterOriginalPcmBackup, originalPcmData, masterOriginalPcmBackup.Length);
+
+            originalSampleRate = masterOriginalSampleRate;
+            originalFormat = new WaveFormat(masterOriginalSampleRate, 8, 1);
+            isRecorded = true;
+            lastLoadedFilePath = null;
+
+            SetSampleRateComboTextWithoutProcessing(masterOriginalSampleRate, $"{masterOriginalSampleRate}Hz - Master");
+            waveformViewer?.SetAudioData(currentPcmData);
+            waveformViewer?.Invalidate();
+            StoreInitialState();
+            btnBackToMasterSample.Enabled = false;
+            AddToListBox("Master sample restored.");
+        }
+
+        private void UpdatePadPlayingState(int slot)
+        {
+            if (samplePadForm == null || samplePadForm.IsDisposed || slot < 0 || slot >= activePadPlayCounts.Length)
+            {
+                return;
+            }
+
+            bool isPlaying = activePadPlayCounts[slot] > 0;
+            if (samplePadForm.InvokeRequired)
+            {
+                samplePadForm.BeginInvoke(new Action(() => samplePadForm.SetPadPlaying(slot, isPlaying)));
+            }
+            else
+            {
+                samplePadForm.SetPadPlaying(slot, isPlaying);
+            }
+        }
+
+        private void StopAllInteractiveAudio()
+        {
+            StopPreview();
+
+            lock (playbackLock)
+            {
+                foreach (var voice in activePadVoices.ToList())
+                {
+                    StopAndDisposePadVoice(voice);
+                }
+                activePadVoices.Clear();
+
+                for (int i = 0; i < activePadPlayCounts.Length; i++)
+                {
+                    activePadPlayCounts[i] = 0;
+                    UpdatePadPlayingState(i);
+                }
+            }
+
+            try
+            {
+                pianoWaveOut?.Stop();
+            }
+            catch
+            {
+                // Best-effort stop.
+            }
+
+            activePianoOffset = -1;
+            pianoPanel?.Invalidate();
+            AddToListBox("All playback stopped.");
         }
 
         private void ComboBoxPTNote_DrawItem(object sender, DrawItemEventArgs e)
@@ -1198,65 +1578,85 @@ namespace WavConvert4Amiga
             panelWaveform.Visible = true;
 
             // Create a flow layout panel for all buttons at the top
-            FlowLayoutPanel controlPanel = new FlowLayoutPanel();
-            controlPanel.Dock = DockStyle.Top;
-            controlPanel.Padding = new Padding(5);
-            controlPanel.WrapContents = true;
-            controlPanel.AutoSize = true;
-            controlPanel.AutoSizeMode = AutoSizeMode.GrowAndShrink;
-            controlPanel.Margin = new Padding(0);
-            panelWaveform.Controls.Add(controlPanel);
-            InitializeEditButtons(controlPanel);
+            waveformControlPanel = new FlowLayoutPanel();
+            waveformControlPanel.Dock = DockStyle.Top;
+            waveformControlPanel.Padding = new Padding(3);
+            waveformControlPanel.WrapContents = false;
+            waveformControlPanel.AutoSize = false;
+            waveformControlPanel.AutoScroll = true;
+            waveformControlPanel.Height = 34;
+            waveformControlPanel.Margin = new Padding(0);
+            panelWaveform.Controls.Add(waveformControlPanel);
+            InitializeEditButtons(waveformControlPanel);
 
             // Common button size
-            Size buttonSize = new Size(100, 25);
+            Size buttonSize = new Size(86, 22);
 
             // Add Clear Button
             Button btnClearWaveform = new RetroButton();
             btnClearWaveform.Text = "Clear";
-            btnClearWaveform.Size = new Size(100, 25);
+            btnClearWaveform.Size = buttonSize;
             btnClearWaveform.Click += BtnClearWaveform_Click;
-            controlPanel.Controls.Add(btnClearWaveform);
+            waveformControlPanel.Controls.Add(btnClearWaveform);
 
             //Zoom Buttons
             btnZoomIn = new RetroButton();
             btnZoomIn.Text = "Zoom In";
-            btnZoomIn.Size = new Size(100, 25);
+            btnZoomIn.Size = buttonSize;
             btnZoomIn.Click += BtnZoomIn_Click;
-            controlPanel.Controls.Add(btnZoomIn);
+            waveformControlPanel.Controls.Add(btnZoomIn);
 
             btnZoomOut = new RetroButton();
             btnZoomOut.Text = "Zoom Out";
-            btnZoomOut.Size = new Size(100, 25);
+            btnZoomOut.Size = buttonSize;
             btnZoomOut.Click += BtnZoomOut_Click;
-            controlPanel.Controls.Add(btnZoomOut);
+            waveformControlPanel.Controls.Add(btnZoomOut);
 
             // Add Save Loop Points (8SVX) button
             Button btnSaveLoop8SVX = new RetroButton();
             btnSaveLoop8SVX.Text = "Save Loop Points (8SVX)";
-            btnSaveLoop8SVX.Size = new Size(160, 25); // Wider for longer text
+            btnSaveLoop8SVX.Size = new Size(170, 22); // Wider for longer text
             btnSaveLoop8SVX.Click += BtnSaveLoop8SVX_Click;
-            controlPanel.Controls.Add(btnSaveLoop8SVX);
+            waveformControlPanel.Controls.Add(btnSaveLoop8SVX);
 
             // Add Save Loop button
             Button btnSaveLoop = new RetroButton();
             btnSaveLoop.Text = "Save Loop";
             btnSaveLoop.Size = buttonSize;
             btnSaveLoop.Click += BtnSaveLoop_Click;
-            controlPanel.Controls.Add(btnSaveLoop);
+            waveformControlPanel.Controls.Add(btnSaveLoop);
 
             Button btnSaveSample = new RetroButton();
             btnSaveSample.Text = "Save Sample";
             btnSaveSample.Size = buttonSize;
             btnSaveSample.Click += BtnSaveSample_Click;
-            controlPanel.Controls.Add(btnSaveSample);
+            waveformControlPanel.Controls.Add(btnSaveSample);
 
             // Add Preview button
             btnPreviewLoop = new RetroButton();
             btnPreviewLoop.Text = "Preview";
             btnPreviewLoop.Size = buttonSize;
             btnPreviewLoop.Click += BtnPreviewLoop_Click;
-            controlPanel.Controls.Add(btnPreviewLoop);
+            waveformControlPanel.Controls.Add(btnPreviewLoop);
+
+            btnStopAllAudio = new RetroButton();
+            btnStopAllAudio.Text = "Stop All";
+            btnStopAllAudio.Size = buttonSize;
+            btnStopAllAudio.Click += (s, e) => StopAllInteractiveAudio();
+            waveformControlPanel.Controls.Add(btnStopAllAudio);
+
+            btnPadAssign = new RetroButton();
+            btnPadAssign.Text = "PAD";
+            btnPadAssign.Size = buttonSize;
+            btnPadAssign.Click += BtnPadAssign_Click;
+            waveformControlPanel.Controls.Add(btnPadAssign);
+
+            btnBackToMasterSample = new RetroButton();
+            btnBackToMasterSample.Text = "Back to Master";
+            btnBackToMasterSample.Size = new Size(120, 22);
+            btnBackToMasterSample.Enabled = false;
+            btnBackToMasterSample.Click += BtnBackToMasterSample_Click;
+            waveformControlPanel.Controls.Add(btnBackToMasterSample);
 
             // Initialize the waveform viewer AFTER the control panel
             waveformViewer = new WaveformViewer();
@@ -1276,6 +1676,12 @@ namespace WavConvert4Amiga
             {
                 waveformViewer.SetAudioData(currentPcmData);
             }
+
+            BeginInvoke(new Action(() =>
+            {
+                waveformControlPanel?.PerformLayout();
+                panelWaveform?.PerformLayout();
+            }));
         }
 
         private void BtnZoomIn_Click(object sender, EventArgs e)
@@ -1292,6 +1698,7 @@ namespace WavConvert4Amiga
         {
             // Stop any ongoing playback
             StopPreview();
+            ClearMasterSampleBackup();
 
             // Clear all state
             ClearAllState();
@@ -2341,10 +2748,11 @@ namespace WavConvert4Amiga
 
         private void InitializeEditButtons(FlowLayoutPanel controlPanel)
         {
+            Size editButtonSize = new Size(86, 22);
             // Cut button
             btnCut = new RetroButton();
             btnCut.Text = "Cut";
-            btnCut.Size = new Size(100, 25);
+            btnCut.Size = editButtonSize;
             btnCut.Click += BtnCut_Click;
             btnCut.Enabled = false; // Disabled until loop points are set
             controlPanel.Controls.Add(btnCut);
@@ -2352,7 +2760,7 @@ namespace WavConvert4Amiga
             // Crop-to-loop button (reverse cut)
             btnCropToLoop = new RetroButton();
             btnCropToLoop.Text = "Crop to Loop";
-            btnCropToLoop.Size = new Size(100, 25);
+            btnCropToLoop.Size = new Size(110, 22);
             btnCropToLoop.Click += BtnCropToLoop_Click;
             btnCropToLoop.Enabled = false; // Disabled until loop points are set
             controlPanel.Controls.Add(btnCropToLoop);
@@ -2360,7 +2768,7 @@ namespace WavConvert4Amiga
             // Undo button
             btnUndo = new RetroButton();
             btnUndo.Text = "Undo";
-            btnUndo.Size = new Size(100, 25);
+            btnUndo.Size = editButtonSize;
             btnUndo.Click += BtnUndo_Click;
             btnUndo.Enabled = false;
             controlPanel.Controls.Add(btnUndo);
@@ -2368,7 +2776,7 @@ namespace WavConvert4Amiga
             // Redo button
             btnRedo = new RetroButton();
             btnRedo.Text = "Redo";
-            btnRedo.Size = new Size(100, 25);
+            btnRedo.Size = editButtonSize;
             btnRedo.Click += BtnRedo_Click;
             btnRedo.Enabled = false;
             controlPanel.Controls.Add(btnRedo);
@@ -3764,6 +4172,7 @@ namespace WavConvert4Amiga
             SetCustomCursor("busy");
             try
             {
+                ClearMasterSampleBackup();
                 ClearAllState();
                // undoStack.Clear();
                // redoStack.Clear();
@@ -4805,6 +5214,20 @@ namespace WavConvert4Amiga
             pianoWaveOut?.Dispose();
             pianoWaveStream?.Dispose();
             pianoAudioStream?.Dispose();
+            lock (playbackLock)
+            {
+                foreach (var voice in activePadVoices.ToList())
+                {
+                    StopAndDisposePadVoice(voice);
+                }
+                activePadVoices.Clear();
+                for (int i = 0; i < activePadPlayCounts.Length; i++)
+                {
+                    activePadPlayCounts[i] = 0;
+                }
+            }
+            padAssignContextMenu?.Dispose();
+            samplePadForm?.Close();
         }
 
         private void ApplyAmigaStyle(Control.ControlCollection controls)

--- a/WavConvert4Amiga/WavConvert4Amiga.csproj
+++ b/WavConvert4Amiga/WavConvert4Amiga.csproj
@@ -159,6 +159,7 @@
     <Compile Include="RetroButton.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="SamplePadForm.cs" />
     <Compile Include="WaveformProcessor.cs" />
     <Compile Include="WaveformViewer.code.cs.cs">
       <SubType>UserControl</SubType>


### PR DESCRIPTION
### Motivation

- Provide a detachable 4x4 sample PAD so users can trigger samples quickly from the editor or keyboard.
- Allow assigning the current editor sample to PAD slots and editing PAD slots back in the main editor to streamline workflow.
- Support concurrent PAD playback with visual indicators and a global "Stop All" control to manage interactive audio.

### Description

- Added a new `SamplePadForm` class that implements a 4x4 PAD UI with key mapping, left-click play, right-click edit, and visual states for loaded/playing slots.
- Integrated PAD state into the main form by adding `padSlots`, a `PadPlaybackVoice` class, `activePadVoices`, play-count tracking, and methods `AssignCurrentSampleToPadSlot`, `PlayPadSlot`, `EditPadSlotInMain`, `StopAndDisposePadVoice`, `UpdatePadPlayingState`, `StopAllInteractiveAudio`, and PAD window management via `EnsureSamplePadWindow` and `CheckBoxShowPad_CheckedChanged`.
- Added master-sample backup/restore functionality with `SaveMasterSampleBackup`, `RestoreMasterSampleBackup`, and `ClearMasterSampleBackup`, and UI controls `btnPadAssign`, `btnStopAllAudio`, `btnBackToMasterSample`, and `checkBoxShowPad` plus wiring into the waveform controls.
- Refactored the waveform control area to use `waveformControlPanel` (a `FlowLayoutPanel`), adjusted button sizes/layout, and added the new PAD-related buttons; included `SamplePadForm.cs` in the project file (`.csproj`).

### Testing

- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9672d2e08832d8454c9f1f4636715)