### PR TITLE
Fix compressed top toolbar layout on startup

### DIFF
--- a/WavConvert4Amiga/WavConvert4Amiga-Main.Designer.cs
+++ b/WavConvert4Amiga/WavConvert4Amiga-Main.Designer.cs
@@ -264,7 +264,7 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.AutoSize = true;
+            this.AutoSize = false;
             this.BackColor = System.Drawing.SystemColors.Control;
             this.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
             this.ClientSize = new System.Drawing.Size(1507, 844);

--- a/WavConvert4Amiga/WavConvert4Amiga-Main.cs
+++ b/WavConvert4Amiga/WavConvert4Amiga-Main.cs
@@ -359,7 +359,6 @@ namespace WavConvert4Amiga
                 const int margin = 16;
                 const int gap = 8;
                 int row1Y = 10;
-                int row2Y = 42;
 
                 label1.Location = new Point(margin, row1Y + 4);
                 comboBoxSampleRate.Location = new Point(label1.Right + gap, row1Y);
@@ -405,6 +404,13 @@ namespace WavConvert4Amiga
                 placeRight(checkBoxEnable8SVX, row1Y + 3);
                 placeRight(checkBox16BitWAV, row1Y + 3);
                 placeRight(checkBoxShowPad, row1Y + 3);
+
+                int topRowHeight = Math.Max(
+                    comboBoxSampleRate.Height,
+                    Math.Max(
+                        (checkBoxShowPad?.Bottom ?? checkBox16BitWAV.Bottom) - row1Y,
+                        (comboBoxPTNote?.Bottom ?? comboBoxSampleRate.Bottom) - row1Y));
+                int row2Y = row1Y + topRowHeight + gap;
 
                 int leftClusterRight = checkBoxPianoMode != null ? checkBoxPianoMode.Right : checkBoxNTSC.Right;
                 if (checkBoxShowPad != null && checkBoxShowPad.Left < leftClusterRight + gap)


### PR DESCRIPTION
### Motivation
- The top toolbar controls could be vertically crushed on startup or high-DPI environments because the second-row Y coordinate was hard-coded and the form was allowed to `AutoSize`, causing layout collisions.
- Make the header layout robust by computing the first-row height from the actual controls so the second row is placed beneath the tallest top control.

### Description
- Compute `topRowHeight` in `LayoutMainFormControls` and derive `row2Y` from it instead of using a fixed offset, so the second-row buttons are positioned beneath the tallest first-row control (`WavConvert4Amiga/WavConvert4Amiga-Main.cs`).
- Keep the existing right-side checkbox overflow fallback but anchor it to the newly computed `row2Y` to avoid overlaps when space is tight (`WavConvert4Amiga/WavConvert4Amiga-Main.cs`).
- Disable form `AutoSize` in the designer to prevent startup autosizing behavior that could compress the header area (`WavConvert4Amiga/WavConvert4Amiga-Main.Designer.cs`).

### Testing
- Attempted to run `dotnet build WavConvert4Amiga.sln`, but the environment does not have `dotnet` installed, so an automated build could not be completed (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da8e0b3be4832d94e2ab016203e169)