### PR TITLE
Preserve master sample backup across PAD edits and destructive edits

### DIFF
--- a/WavConvert4Amiga/WavConvert4Amiga-Main.cs
+++ b/WavConvert4Amiga/WavConvert4Amiga-Main.cs
@@ -1005,6 +1005,8 @@ namespace WavConvert4Amiga
                 return;
             }
 
+            SaveMasterSampleBackup();
+
             byte[] copiedAudio = new byte[currentPcmData.Length];
             Array.Copy(currentPcmData, copiedAudio, currentPcmData.Length);
 
@@ -1185,7 +1187,7 @@ namespace WavConvert4Amiga
 
         private void SaveMasterSampleBackup()
         {
-            if (currentPcmData == null || currentPcmData.Length == 0)
+            if (hasMasterBackup || currentPcmData == null || currentPcmData.Length == 0)
             {
                 return;
             }
@@ -1773,6 +1775,7 @@ namespace WavConvert4Amiga
 
             // Store original length for logging
             int originalLength = currentPcmData.Length;
+            SaveMasterSampleBackup();
 
             // IMPORTANT: Store current state in undo stack BEFORE making changes
             PushUndo(currentPcmData);
@@ -1823,6 +1826,7 @@ namespace WavConvert4Amiga
 
             int originalLength = currentPcmData.Length;
             int currentSampleRate = waveformViewer?.CurrentSampleRate ?? GetSelectedSampleRate();
+            SaveMasterSampleBackup();
 
             PushUndo(currentPcmData);
             redoStack.Clear();


### PR DESCRIPTION
### Motivation
- `Back to Master` could fail to restore the original sample after assigning samples to PAD slots or performing destructive edits because a master backup was not always captured or was overwritten by later edits.

### Description
- Call `SaveMasterSampleBackup()` when assigning the current sample to a PAD slot (`AssignCurrentSampleToPadSlot`).
- Call `SaveMasterSampleBackup()` before destructive edits in `BtnCut_Click` and `BtnCropToLoop_Click` so the original master is preserved.
- Update `SaveMasterSampleBackup()` to return early when `hasMasterBackup` is already true to avoid overwriting the initial master snapshot.

### Testing
- Attempted to build with `dotnet build WavConvert4Amiga.sln`, which failed in this environment due to `dotnet: command not found`.
- No automated unit test suite was run in this environment; changes were verified by inspecting the modified source file and committing the update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbd39c2858832dbc08749592e8bc5f)