### PR TITLE
Smooth pad and piano sample tails to prevent end clicks

### DIFF
--- a/WavConvert4Amiga/WavConvert4Amiga-Main.cs
+++ b/WavConvert4Amiga/WavConvert4Amiga-Main.cs
@@ -948,7 +948,8 @@ namespace WavConvert4Amiga
                     pianoAudioStream?.Dispose();
                     pianoAudioStream = null;
 
-                    pianoAudioStream = new MemoryStream(currentPcmData, false);
+                    byte[] playbackData = CreateTailSmoothedPlaybackCopy(currentPcmData);
+                    pianoAudioStream = new MemoryStream(playbackData, false);
                     pianoWaveStream = new RawSourceWaveStream(pianoAudioStream, new WaveFormat(noteSampleRate, 8, 1));
 
                     pianoWaveOut.Init(pianoWaveStream);
@@ -1091,7 +1092,8 @@ namespace WavConvert4Amiga
                         }
                     };
 
-                    voice.AudioStream = new MemoryStream(slotInfo.AudioData, false);
+                    byte[] playbackData = CreateTailSmoothedPlaybackCopy(slotInfo.AudioData);
+                    voice.AudioStream = new MemoryStream(playbackData, false);
                     voice.WaveStream = new RawSourceWaveStream(voice.AudioStream, new WaveFormat(slotInfo.SampleRate, 8, 1));
                     voice.Output.Init(voice.WaveStream);
                     voice.Output.PlaybackStopped += (s, e) =>
@@ -1123,6 +1125,33 @@ namespace WavConvert4Amiga
             {
                 // keep pad playback resilient without interrupting editing workflow
             }
+        }
+
+        private byte[] CreateTailSmoothedPlaybackCopy(byte[] sourceData)
+        {
+            if (sourceData == null || sourceData.Length == 0)
+            {
+                return Array.Empty<byte>();
+            }
+
+            byte[] playbackData = new byte[sourceData.Length];
+            Array.Copy(sourceData, playbackData, sourceData.Length);
+
+            // 8-bit PCM in this app is unsigned, so silence is centered at 128.
+            // A very short fade-to-center at the tail avoids end-of-sample clicks.
+            const int fadeSamples = 64;
+            int fadeLength = Math.Min(fadeSamples, playbackData.Length);
+            int fadeStart = playbackData.Length - fadeLength;
+            for (int i = 0; i < fadeLength; i++)
+            {
+                int index = fadeStart + i;
+                float t = (i + 1) / (float)fadeLength;
+                float sample = playbackData[index];
+                float smoothed = sample + (128f - sample) * t;
+                playbackData[index] = (byte)Math.Round(Math.Max(0f, Math.Min(255f, smoothed)));
+            }
+
+            return playbackData;
         }
 
         private void StopAndDisposePadVoice(PadPlaybackVoice voice, bool resetPadIndicators = false)


### PR DESCRIPTION
### Motivation
- Short one-shot samples played from the PAD or in piano mode produced audible clicks at sample end due to abrupt discontinuities in 8-bit unsigned PCM buffers.

### Description
- Use a playback-only smoothed copy for piano playback by replacing the direct `MemoryStream(currentPcmData)` with `CreateTailSmoothedPlaybackCopy(currentPcmData)` in `PlayPianoSample`.
- Use the same smoothed-copy path for PAD playback by creating `CreateTailSmoothedPlaybackCopy(slotInfo.AudioData)` before building the PAD `MemoryStream` in `PlayPadSlot`.
- Added `CreateTailSmoothedPlaybackCopy(byte[] sourceData)` which copies the source buffer and applies a short 64-sample fade-to-center for unsigned 8-bit PCM (silence centered at `128`) at the tail, leaving stored sample data unchanged.
- Changes are in `WavConvert4Amiga/WavConvert4Amiga-Main.cs`.

### Testing
- Attempted to build with `msbuild WavConvert4Amiga.sln /t:Build /p:Configuration=Release`, but `msbuild` is not available in the environment (build not performed).
- Attempted to build with `dotnet build WavConvert4Amiga.sln -c Release`, but `dotnet` is not available in the environment (build not performed).
- No automated unit tests were run in this environment; behavior validated by code-level inspection and targeted change scope to only affect playback buffers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbd567b3e0832d814dd402479566bc)