### PR TITLE
Prevent duplicate queue entries from drag-and-drop

### DIFF
--- a/WavConvert4Amiga/WavConvert4Amiga-Main.cs
+++ b/WavConvert4Amiga/WavConvert4Amiga-Main.cs
@@ -340,8 +340,9 @@ namespace WavConvert4Amiga
         {
             previousClientSize = this.ClientSize;
             panel1.AllowDrop = true;
-            panel1.DragEnter += panel1_DragEnter;
-            panel1.DragDrop += panel1_DragDrop;
+
+            // DragEnter and DragDrop are wired in InitializeComponent. Re-attaching
+            // them here makes one dropped file enqueue twice.
 
             // Populate the ComboBox with common values
             comboBoxSampleRate.Items.Add("150Hz - BitCrushed+++");


### PR DESCRIPTION
### Motivation
- Dropping a file onto the panel caused the same file to be enqueued twice because the `DragEnter`/`DragDrop` handlers were attached both by the designer (`InitializeComponent`) and again at runtime in `MainForm_Load`.

### Description
- Removed the duplicate `panel1.DragEnter` and `panel1.DragDrop` handler attachments from `MainForm_Load` and added a clarifying comment that the handlers are already wired in `InitializeComponent` so a single drop is only processed once.

### Testing
- Ran a source check `rg -n "panel1\.Drag(Enter|Drop) \+="` to confirm only the designer registrations remain and ran `git diff --check` for sanity; both checks passed, while `msbuild WavConvert4Amiga.sln` could not be executed in this environment because `msbuild` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19b675b484832d89fe7412e29e0516)