### PR TITLE
Preserve edited audio during amplification

### DIFF
--- a/WavConvert4Amiga/WavConvert4Amiga-Main.cs
+++ b/WavConvert4Amiga/WavConvert4Amiga-Main.cs
@@ -3011,9 +3011,23 @@ namespace WavConvert4Amiga
 
         private byte[] AmplifyAndConvert(byte[] pcmData, float amplificationFactor)
         {
+            if (pcmData == null) return null;
+
+            // Cuts and crop-to-loop are destructive edits that have already been
+            // applied to currentPcmData. Rebuilding from originalPcmData here can
+            // bring removed audio back into the waveform before amplification,
+            // so amplify the edited buffer directly in that case.
+            if (currentCutRegions.Count > 0 || cropSelectionSeconds != null)
+            {
+                return amplificationFactor == 1.0f
+                    ? pcmData
+                    : waveformProcessor.ApplyAmplification(pcmData, amplificationFactor);
+            }
+
             if (originalPcmData == null) return pcmData;
 
-            // Always start from original data and apply all current modifications
+            // With no destructive waveform edits, start from the original source
+            // data so slider changes do not compound on top of previous previews.
             int targetSampleRate = GetSelectedSampleRate();
 
             return ApplyAllModifications(


### PR DESCRIPTION
### Motivation
- Amplifying after performing destructive edits (cut/crop) would rebuild audio from `originalPcmData`, causing removed audio to reappear instead of amplifying the already-edited waveform.

### Description
- Update `AmplifyAndConvert` in `WavConvert4Amiga/WavConvert4Amiga-Main.cs` to return early for `null` input and to detect destructive edits (`currentCutRegions` or `cropSelectionSeconds`) and amplify the supplied `pcmData` directly using `waveformProcessor.ApplyAmplification` when present.
- Preserve the previous behavior for non-destructive cases by continuing to call `ApplyAllModifications` on `originalPcmData` so slider previews still rebuild from the source and do not compound on prior previews.
- Added clarifying comments to explain why edited buffers are amplified directly and when the original source is used.

### Testing
- Ran `git diff --check` which reported no whitespace or diff errors; it succeeded.
- Queried `dotnet --info` and .NET build tooling checks (`msbuild`, `xbuild`, `nuget`) and C# compilers (`csc`, `mcs`) in the environment and these tools are not available in this runner, so a full build could not be executed.
- No automated unit tests exist for this behavior in the repository, so changes were validated by static inspection of the modified `AmplifyAndConvert` logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ab73a7f30832db5a3b7c2ba0b13aa)