### PR TITLE
Add 8SVX Fibonacci-delta compression support and UI/queue controls

### DIFF
--- a/WavConvert4Amiga/QueueItem.cs
+++ b/WavConvert4Amiga/QueueItem.cs
@@ -27,5 +27,6 @@ namespace WavConvert4Amiga
         public bool MoveOriginal { get; set; }
         public bool SaveAs8Svx { get; set; }
         public bool SaveAs16BitWav { get; set; }
+        public bool Compress8Svx { get; set; }
     }
 }

--- a/WavConvert4Amiga/SVXLoader.cs
+++ b/WavConvert4Amiga/SVXLoader.cs
@@ -10,12 +10,19 @@ using NAudio.Wave;
     {
     public class SVXLoader
     {
+        private const byte sCmpNone = 0;
+        public const byte sCmpFibDelta = 1;
+        private static readonly int[] CodeToDelta = { -34, -21, -13, -8, -5, -3, -2, -1, 0, 1, 2, 3, 5, 8, 13, 21 };
+
         public class SVXInfo
         {
             public byte[] AudioData { get; set; }
             public int SampleRate { get; set; }
             public int LoopStart { get; set; }
             public int LoopEnd { get; set; }
+            public byte Compression { get; set; }
+            public int TotalSamples { get; set; }
+            public bool IsFibonacciDeltaCompressed => Compression == sCmpFibDelta;
         }
 
         public static SVXInfo Load8SVXFile(string filePath)
@@ -33,7 +40,7 @@ using NAudio.Wave;
                     if (formType != "FORM")
                         throw new InvalidDataException("Not a valid IFF file (missing FORM header)");
 
-                    uint fileLength = (uint)ReverseBytes(reader.ReadInt32());
+                    uint fileLength = ReadUInt32BigEndian(reader);
                     if (fileLength + 8 > fileSize)
                         throw new InvalidDataException("Invalid IFF file size");
 
@@ -45,17 +52,20 @@ using NAudio.Wave;
                     {
                         LoopStart = -1,
                         LoopEnd = -1,
-                        SampleRate = 8363 // Default if not specified
+                        SampleRate = 8363, // Default if not specified
+                        Compression = sCmpNone
                     };
 
+                    byte[] bodyData = null;
                     while (reader.BaseStream.Position < reader.BaseStream.Length - 8)
                     {
                         string chunkName = new string(reader.ReadChars(4));
-                        uint chunkSize = (uint)ReverseBytes(reader.ReadInt32());
+                        uint chunkSize = ReadUInt32BigEndian(reader);
 
                         if (reader.BaseStream.Position + chunkSize > fileSize)
                             throw new InvalidDataException("Invalid chunk size");
 
+                        long chunkDataStart = reader.BaseStream.Position;
                         switch (chunkName)
                         {
                             case "VHDR":
@@ -63,18 +73,53 @@ using NAudio.Wave;
                                 break;
 
                             case "BODY":
-                                info.AudioData = ProcessBODYChunk(reader, (int)chunkSize);
+                                bodyData = ReadBODYChunk(reader, (int)chunkSize);
                                 break;
 
                             default:
-                                reader.BaseStream.Seek(chunkSize + (chunkSize % 2), SeekOrigin.Current);
+                                reader.BaseStream.Seek(chunkSize, SeekOrigin.Current);
                                 break;
+                        }
+
+                        long chunkDataEnd = chunkDataStart + chunkSize;
+                        if (reader.BaseStream.Position < chunkDataEnd)
+                        {
+                            reader.BaseStream.Seek(chunkDataEnd, SeekOrigin.Begin);
+                        }
+
+                        if ((chunkSize & 1) == 1 && reader.BaseStream.Position < reader.BaseStream.Length)
+                        {
+                            reader.BaseStream.Seek(1, SeekOrigin.Current);
                         }
                     }
 
-                    if (info.AudioData == null || info.AudioData.Length == 0)
+                    if (bodyData == null || bodyData.Length == 0)
                         throw new InvalidDataException("No audio data found in 8SVX file");
 
+                    byte[] signedData;
+                    if (info.Compression == sCmpFibDelta)
+                    {
+                        signedData = DecompressFibonacciDeltaSigned(bodyData);
+                    }
+                    else if (info.Compression == sCmpNone)
+                    {
+                        signedData = bodyData;
+                    }
+                    else
+                    {
+                        throw new InvalidDataException($"Unsupported 8SVX compression type: {info.Compression}");
+                    }
+
+                    int declaredSampleCount = GetDeclaredSampleCount(info);
+                    if (info.Compression == sCmpFibDelta &&
+                        declaredSampleCount > 0 &&
+                        signedData.Length == declaredSampleCount + 1)
+                    {
+                        // Odd sample counts are stored as a final padded nybble, so drop only that synthetic sample.
+                        Array.Resize(ref signedData, declaredSampleCount);
+                    }
+
+                    info.AudioData = ConvertSignedToUnsigned(signedData);
                     return info;
                 }
             }
@@ -84,43 +129,176 @@ using NAudio.Wave;
             }
         }
 
-        private static void ProcessVHDRChunk(BinaryReader reader, SVXInfo info, int chunkSize)
+        public static byte[] CompressFibonacciDelta(byte[] unsignedPcmData)
         {
-            if (chunkSize < 14)
-                throw new InvalidDataException("VHDR chunk is too small");
+            if (unsignedPcmData == null)
+                throw new ArgumentNullException(nameof(unsignedPcmData));
 
-            reader.BaseStream.Seek(8, SeekOrigin.Current); // Skip oneShotHiSamples and repeatHiSamples
-            reader.BaseStream.Seek(4, SeekOrigin.Current); // Skip samplesPerHiCycle
-            // Read sample rate directly as a word value
-            ushort sampleRate = (ushort)(reader.ReadByte() << 8 | reader.ReadByte());
-            info.SampleRate = sampleRate > 0 ? sampleRate : 8363;
-            reader.BaseStream.Seek(chunkSize - 14, SeekOrigin.Current);
+            byte[] signedData = new byte[unsignedPcmData.Length];
+            for (int i = 0; i < unsignedPcmData.Length; i++)
+            {
+                signedData[i] = unchecked((byte)(unsignedPcmData[i] - 128));
+            }
+
+            return CompressFibonacciDeltaSigned(signedData);
         }
 
-        private static byte[] ProcessBODYChunk(BinaryReader reader, int chunkSize)
+        public static byte[] RoundTripFibonacciDelta(byte[] unsignedPcmData)
+        {
+            if (unsignedPcmData == null)
+                return null;
+
+            byte[] compressed = CompressFibonacciDelta(unsignedPcmData);
+            byte[] decompressedSigned = DecompressFibonacciDeltaSigned(compressed);
+            if (decompressedSigned.Length > unsignedPcmData.Length)
+            {
+                Array.Resize(ref decompressedSigned, unsignedPcmData.Length);
+            }
+
+            return ConvertSignedToUnsigned(decompressedSigned);
+        }
+
+        private static void ProcessVHDRChunk(BinaryReader reader, SVXInfo info, int chunkSize)
+        {
+            if (chunkSize < 20)
+                throw new InvalidDataException("VHDR chunk is too small");
+
+            uint oneShotHiSamples = ReadUInt32BigEndian(reader);
+            uint repeatHiSamples = ReadUInt32BigEndian(reader);
+            ReadUInt32BigEndian(reader); // samplesPerHiCycle
+            ushort sampleRate = ReadUInt16BigEndian(reader);
+            info.SampleRate = sampleRate > 0 ? sampleRate : 8363;
+            reader.ReadByte(); // ctOctave
+            info.Compression = reader.ReadByte();
+            ulong totalSamples = oneShotHiSamples + repeatHiSamples;
+            info.TotalSamples = (int)Math.Min(totalSamples, (ulong)int.MaxValue);
+            reader.BaseStream.Seek(4, SeekOrigin.Current); // volume
+
+            if (repeatHiSamples > 0)
+            {
+                info.LoopStart = (int)Math.Min(oneShotHiSamples, int.MaxValue);
+                ulong loopEnd = oneShotHiSamples + repeatHiSamples;
+                info.LoopEnd = (int)Math.Min(loopEnd, (ulong)int.MaxValue);
+            }
+        }
+
+        private static byte[] ReadBODYChunk(BinaryReader reader, int chunkSize)
         {
             if (chunkSize <= 0)
                 throw new InvalidDataException("Invalid BODY chunk size");
 
-            byte[] signedData = reader.ReadBytes(chunkSize);
-            if (signedData.Length != chunkSize)
+            byte[] data = reader.ReadBytes(chunkSize);
+            if (data.Length != chunkSize)
                 throw new InvalidDataException("Unexpected end of file in BODY chunk");
 
+            return data;
+        }
+
+        private static byte[] CompressFibonacciDeltaSigned(byte[] signedData)
+        {
+            byte initialValue = signedData.Length > 0 ? signedData[0] : (byte)0;
+            int encodedByteCount = (signedData.Length + 1) / 2;
+            byte[] body = new byte[encodedByteCount + 2];
+            body[0] = 0; // Pad byte required by the 8SVX Fibonacci-delta BODY format.
+            body[1] = initialValue;
+
+            byte predictor = initialValue;
+            for (int i = 0; i < signedData.Length; i++)
+            {
+                int code = FindClosestDeltaCode(unchecked((sbyte)signedData[i]) - unchecked((sbyte)predictor));
+                predictor = unchecked((byte)(predictor + CodeToDelta[code]));
+
+                int outputIndex = 2 + (i / 2);
+                if ((i & 1) == 0)
+                {
+                    body[outputIndex] = (byte)(code << 4);
+                }
+                else
+                {
+                    body[outputIndex] |= (byte)code;
+                }
+            }
+
+            return body;
+        }
+
+        private static byte[] DecompressFibonacciDeltaSigned(byte[] bodyData)
+        {
+            if (bodyData.Length < 2)
+                throw new InvalidDataException("Compressed 8SVX BODY chunk is too small");
+
+            byte predictor = bodyData[1];
+            byte[] signedData = new byte[(bodyData.Length - 2) * 2];
+            int outputIndex = 0;
+            for (int i = 2; i < bodyData.Length; i++)
+            {
+                byte packedCodes = bodyData[i];
+                predictor = unchecked((byte)(predictor + CodeToDelta[(packedCodes >> 4) & 0x0F]));
+                signedData[outputIndex++] = predictor;
+                predictor = unchecked((byte)(predictor + CodeToDelta[packedCodes & 0x0F]));
+                signedData[outputIndex++] = predictor;
+            }
+
+            return signedData;
+        }
+
+        private static int FindClosestDeltaCode(int targetDelta)
+        {
+            int bestCode = 0;
+            int bestDistance = int.MaxValue;
+            for (int i = 0; i < CodeToDelta.Length; i++)
+            {
+                int distance = Math.Abs(targetDelta - CodeToDelta[i]);
+                if (distance < bestDistance)
+                {
+                    bestDistance = distance;
+                    bestCode = i;
+                }
+            }
+
+            return bestCode;
+        }
+
+        private static byte[] ConvertSignedToUnsigned(byte[] signedData)
+        {
             byte[] unsignedData = new byte[signedData.Length];
             for (int i = 0; i < signedData.Length; i++)
             {
-                unsignedData[i] = (byte)(signedData[i] + 128);
+                unsignedData[i] = unchecked((byte)(signedData[i] + 128));
             }
             return unsignedData;
         }
 
-        private static int ReverseBytes(int value)
+        private static int GetDeclaredSampleCount(SVXInfo info)
         {
-            uint unsigned = (uint)value;
-            return (int)(((unsigned & 0x000000FFu) << 24) |
-                        ((unsigned & 0x0000FF00u) << 8) |
-                        ((unsigned & 0x00FF0000u) >> 8) |
-                        ((unsigned & 0xFF000000u) >> 24));
+            if (info.TotalSamples > 0)
+            {
+                return info.TotalSamples;
+            }
+
+            int sampleCount = 0;
+            if (info.LoopStart > 0)
+            {
+                sampleCount += info.LoopStart;
+            }
+            if (info.LoopEnd > info.LoopStart)
+            {
+                sampleCount += info.LoopEnd - info.LoopStart;
+            }
+            return sampleCount;
+        }
+
+        private static ushort ReadUInt16BigEndian(BinaryReader reader)
+        {
+            return (ushort)((reader.ReadByte() << 8) | reader.ReadByte());
+        }
+
+        private static uint ReadUInt32BigEndian(BinaryReader reader)
+        {
+            return ((uint)reader.ReadByte() << 24) |
+                   ((uint)reader.ReadByte() << 16) |
+                   ((uint)reader.ReadByte() << 8) |
+                   reader.ReadByte();
         }
     }
 }

--- a/WavConvert4Amiga/WavConvert4Amiga-Main.cs
+++ b/WavConvert4Amiga/WavConvert4Amiga-Main.cs
@@ -34,6 +34,7 @@ namespace WavConvert4Amiga
         private ComboBox comboBoxPTNote;
         private CheckBox checkBoxNTSC;
         private CheckBox checkBox16BitWAV;
+        private CheckBox checkBox8SVXFibDelta;
         private WaveOut waveOut;
         private WaveFormat originalFormat; // Store original format
         private MemoryStream audioStream;
@@ -82,6 +83,7 @@ namespace WavConvert4Amiga
         private ToolStripMenuItem queueToggleMoveOriginalMenuItem;
         private ToolStripMenuItem queueToggleSaveAs8SvxMenuItem;
         private ToolStripMenuItem queueToggleSaveAs16BitWavMenuItem;
+        private ToolStripMenuItem queueToggle8SvxCompressionMenuItem;
         private ToolStripMenuItem queueUseCurrentSettingsMenuItem;
         private ToolStripMenuItem queueDeleteMenuItem;
         private ToolStripMenuItem queueLoadPreviewMenuItem;
@@ -217,6 +219,7 @@ namespace WavConvert4Amiga
             StyleCheckbox(checkBoxAutoConvert);
             StyleCheckbox(checkBoxMoveOriginal);
             StyleCheckbox(checkBox16BitWAV);
+            StyleCheckbox(checkBox8SVXFibDelta);
             StyleCheckbox(checkBoxNTSC);
             StyleTrackBar();  // Now the trackbar exists when we try to style it
 
@@ -428,6 +431,7 @@ namespace WavConvert4Amiga
                 placeRight(checkBoxMoveOriginal, row1Y + 3);
                 placeRight(checkBoxAutoConvert, row1Y + 3);
                 placeRight(checkBoxLowPass, row1Y + 3);
+                placeRight(checkBox8SVXFibDelta, row1Y + 3);
                 placeRight(checkBoxEnable8SVX, row1Y + 3);
                 placeRight(checkBox16BitWAV, row1Y + 3);
                 placeRight(checkBoxShowPad, row1Y + 3);
@@ -625,6 +629,15 @@ namespace WavConvert4Amiga
         }
         private void InitializeCheckboxes()
         {
+            checkBox8SVXFibDelta = new CheckBox
+            {
+                AutoSize = true,
+                Text = "Fib Δ",
+                UseVisualStyleBackColor = true
+            };
+            checkBox8SVXFibDelta.CheckedChanged += checkBox8SVXFibDelta_CheckedChanged;
+            Controls.Add(checkBox8SVXFibDelta);
+
             // Set up initial handling of checkbox state changes
             checkBoxEnable8SVX.CheckedChanged += (s, e) =>
             {
@@ -633,6 +646,7 @@ namespace WavConvert4Amiga
                 {
                     checkBox16BitWAV.Checked = false;
                 }
+                checkBox8SVXFibDelta.Enabled = checkBoxEnable8SVX.Checked;
             };
 
             checkBox16BitWAV.CheckedChanged += (s, e) =>
@@ -643,6 +657,8 @@ namespace WavConvert4Amiga
                     checkBoxEnable8SVX.Checked = false;
                 }
             };
+
+            checkBox8SVXFibDelta.Enabled = checkBoxEnable8SVX.Checked;
         }
 
         private void SetCustomCursor(string cursorType)
@@ -1558,6 +1574,9 @@ namespace WavConvert4Amiga
             queueToggleSaveAs16BitWavMenuItem = new ToolStripMenuItem("Save as 16-bit WAV");
             queueToggleSaveAs16BitWavMenuItem.Click += QueueToggleSaveAs16BitWavMenuItem_Click;
 
+            queueToggle8SvxCompressionMenuItem = new ToolStripMenuItem("Use 8SVX Fibonacci compression");
+            queueToggle8SvxCompressionMenuItem.Click += QueueToggle8SvxCompressionMenuItem_Click;
+
             queueUseCurrentSettingsMenuItem = new ToolStripMenuItem("Use current panel settings");
             queueUseCurrentSettingsMenuItem.Click += QueueUseCurrentSettingsMenuItem_Click;
 
@@ -1575,6 +1594,7 @@ namespace WavConvert4Amiga
             queueItemContextMenu.Items.Add(queueToggleMoveOriginalMenuItem);
             queueItemContextMenu.Items.Add(queueToggleSaveAs8SvxMenuItem);
             queueItemContextMenu.Items.Add(queueToggleSaveAs16BitWavMenuItem);
+            queueItemContextMenu.Items.Add(queueToggle8SvxCompressionMenuItem);
             queueItemContextMenu.Items.Add(queueUseCurrentSettingsMenuItem);
             queueItemContextMenu.Items.Add(new ToolStripSeparator());
             queueItemContextMenu.Items.Add(queueDeleteMenuItem);
@@ -1626,6 +1646,7 @@ namespace WavConvert4Amiga
             queueToggleMoveOriginalMenuItem.Enabled = canModify;
             queueToggleSaveAs8SvxMenuItem.Enabled = canModify;
             queueToggleSaveAs16BitWavMenuItem.Enabled = canModify;
+            queueToggle8SvxCompressionMenuItem.Enabled = canModify;
             queueUseCurrentSettingsMenuItem.Enabled = canModify;
             queueDeleteMenuItem.Enabled = canModify;
 
@@ -1634,6 +1655,7 @@ namespace WavConvert4Amiga
             queueToggleMoveOriginalMenuItem.Checked = selectedItem.MoveOriginal;
             queueToggleSaveAs8SvxMenuItem.Checked = selectedItem.SaveAs8Svx;
             queueToggleSaveAs16BitWavMenuItem.Checked = selectedItem.SaveAs16BitWav;
+            queueToggle8SvxCompressionMenuItem.Checked = selectedItem.Compress8Svx;
 
             foreach (ToolStripItem subItem in queueSampleRateMenuItem.DropDownItems)
             {
@@ -2767,6 +2789,11 @@ namespace WavConvert4Amiga
                 {
                     float cutoffFrequency = targetSampleRate * 0.45f;
                     sectionToPlay = waveformProcessor.ApplyLowPassFilter(sectionToPlay, targetSampleRate, cutoffFrequency);
+                }
+
+                if (checkBox8SVXFibDelta?.Checked == true)
+                {
+                    sectionToPlay = SVXLoader.RoundTripFibonacciDelta(sectionToPlay);
                 }
 
                 audioStream = new MemoryStream(sectionToPlay);
@@ -3948,7 +3975,8 @@ namespace WavConvert4Amiga
                 AutoConvert = checkBoxAutoConvert.Checked,
                 MoveOriginal = checkBoxMoveOriginal.Checked,
                 SaveAs8Svx = checkBoxEnable8SVX.Checked,
-                SaveAs16BitWav = checkBox16BitWAV.Checked
+                SaveAs16BitWav = checkBox16BitWAV.Checked,
+                Compress8Svx = checkBox8SVXFibDelta?.Checked ?? false
             };
         }
 
@@ -4118,6 +4146,24 @@ namespace WavConvert4Amiga
             AddToListBox($"Queue: Save as 16-bit WAV {(selectedItem.SaveAs16BitWav ? "enabled" : "disabled")} for {Path.GetFileName(selectedItem.FilePath)}");
         }
 
+        private void QueueToggle8SvxCompressionMenuItem_Click(object sender, EventArgs e)
+        {
+            QueueItem selectedItem = GetSelectedQueueItem();
+            if (selectedItem == null)
+            {
+                return;
+            }
+
+            selectedItem.Compress8Svx = !selectedItem.Compress8Svx;
+            if (selectedItem.Compress8Svx)
+            {
+                selectedItem.SaveAs8Svx = true;
+                selectedItem.SaveAs16BitWav = false;
+            }
+
+            AddToListBox($"Queue: 8SVX Fibonacci compression {(selectedItem.Compress8Svx ? "enabled" : "disabled")} for {Path.GetFileName(selectedItem.FilePath)}");
+        }
+
         private void QueueUseCurrentSettingsMenuItem_Click(object sender, EventArgs e)
         {
             QueueItem selectedItem = GetSelectedQueueItem();
@@ -4137,6 +4183,7 @@ namespace WavConvert4Amiga
             selectedItem.MoveOriginal = currentSettings.MoveOriginal;
             selectedItem.SaveAs8Svx = currentSettings.SaveAs8Svx;
             selectedItem.SaveAs16BitWav = currentSettings.SaveAs16BitWav;
+            selectedItem.Compress8Svx = currentSettings.Compress8Svx;
 
             RefreshQueueItemRow(selectedItem);
             AddToListBox($"Queue: Copied current settings to {Path.GetFileName(selectedItem.FilePath)}");
@@ -4195,6 +4242,7 @@ namespace WavConvert4Amiga
             labelAmplify.Text = $"Amplify: {trackBarAmplify.Value}%";
             checkBoxEnable8SVX.Checked = item.SaveAs8Svx;
             checkBox16BitWAV.Checked = item.SaveAs16BitWav;
+            checkBox8SVXFibDelta.Checked = item.Compress8Svx;
             checkBoxMoveOriginal.Checked = item.MoveOriginal;
             checkBoxAutoConvert.Checked = item.AutoConvert;
         }
@@ -4303,6 +4351,7 @@ namespace WavConvert4Amiga
                         originalPcmData = info.AudioData;
                         originalFormat = new WaveFormat(info.SampleRate, 8, 1);
                         originalSampleRate = info.SampleRate;
+                        checkBox8SVXFibDelta.Checked = false;
                     }
                     else
                     {
@@ -4329,6 +4378,7 @@ namespace WavConvert4Amiga
                         originalPcmData = info.AudioData;
                         originalFormat = new WaveFormat(info.SampleRate, 8, 1);
                         originalSampleRate = info.SampleRate;
+                        checkBox8SVXFibDelta.Checked = info.IsFibonacciDeltaCompressed;
                     }
                 }
                 else if (extension == ".wav")
@@ -4872,18 +4922,38 @@ namespace WavConvert4Amiga
             }
         }
 
+        private void checkBox8SVXFibDelta_CheckedChanged(object sender, EventArgs e)
+        {
+            if (isPlaying && currentPcmData != null)
+            {
+                if (currentPreviewStart >= 0 && currentPreviewEnd > currentPreviewStart)
+                {
+                    StartPreview(currentPreviewStart, currentPreviewEnd);
+                }
+                else
+                {
+                    StartPreview(0, currentPcmData.Length);
+                }
+            }
+        }
+
         private void SaveAs8SVX(byte[] pcmData, string output8SVXFile, int sampleRate)
         {
             // Get loop points if set
             var (loopStart, loopEnd) = waveformViewer.GetLoopPoints();
             int loopLength = (loopEnd > loopStart) ? loopEnd - loopStart : 0;
+            bool useFibDeltaCompression = checkBox8SVXFibDelta?.Checked == true;
 
-            // Convert unsigned PCM (0-255) to signed (-128 to 127)
+            // Convert unsigned PCM (0-255) to signed (-128 to 127) for uncompressed BODY output.
             byte[] signedPcm = new byte[pcmData.Length];
             for (int i = 0; i < pcmData.Length; i++)
             {
-                signedPcm[i] = (byte)(pcmData[i] - 128);
+                signedPcm[i] = unchecked((byte)(pcmData[i] - 128));
             }
+
+            byte[] bodyData = useFibDeltaCompression
+                ? SVXLoader.CompressFibonacciDelta(pcmData)
+                : signedPcm;
 
             using (var writer = new BinaryWriter(File.Open(output8SVXFile, FileMode.Create)))
             {
@@ -4892,7 +4962,7 @@ namespace WavConvert4Amiga
                               (8 + 20) + // VHDR chunk
                               (8 + 32) + // ANNO chunk
                               (8 + 4) + // CHAN chunk
-                              (8 + signedPcm.Length + (signedPcm.Length % 2)); // BODY chunk with padding
+                              (8 + bodyData.Length + (bodyData.Length % 2)); // BODY chunk with padding
 
                 // FORM Chunk
                 writer.Write("FORM".ToCharArray());
@@ -4902,14 +4972,13 @@ namespace WavConvert4Amiga
                 // VHDR Chunk
                 writer.Write("VHDR".ToCharArray());
                 writer.Write(BitConverter.GetBytes(20).Reverse().ToArray()); // Chunk size
-                writer.Write(BitConverter.GetBytes(signedPcm.Length).Reverse().ToArray()); // OneShotHiSamples
+                writer.Write(BitConverter.GetBytes(pcmData.Length).Reverse().ToArray()); // OneShotHiSamples
                 writer.Write(BitConverter.GetBytes(loopLength).Reverse().ToArray()); // RepeatHiSamples
                 writer.Write(BitConverter.GetBytes(loopLength).Reverse().ToArray()); // SamplesPerHiCycle
-                // Convert sample rate to big-endian bytes
                 byte[] sampleRateBytes = BitConverter.GetBytes((ushort)sampleRate).Reverse().ToArray();
                 writer.Write(sampleRateBytes); // Sample rate - 2 bytes
                 writer.Write((byte)1); // Octaves
-                writer.Write((byte)0); // Compression
+                writer.Write(useFibDeltaCompression ? SVXLoader.sCmpFibDelta : (byte)0); // Compression
                 writer.Write(new byte[] { 0x00, 0x01, 0x00, 0x00 }); // Volume
 
                 // ANNO Chunk
@@ -4924,11 +4993,11 @@ namespace WavConvert4Amiga
 
                 // BODY Chunk
                 writer.Write("BODY".ToCharArray());
-                writer.Write(BitConverter.GetBytes(signedPcm.Length).Reverse().ToArray());
-                writer.Write(signedPcm);
+                writer.Write(BitConverter.GetBytes(bodyData.Length).Reverse().ToArray());
+                writer.Write(bodyData);
 
                 // Add padding byte if needed
-                if (signedPcm.Length % 2 != 0)
+                if (bodyData.Length % 2 != 0)
                 {
                     writer.Write((byte)0);
                 }


### PR DESCRIPTION
### Motivation
- Add support for the 8SVX Fibonacci-delta (`sCmpFibDelta`) compression described in the 8SVX spec so the app can read and write compressed 8SVX samples. 
- Allow users to audition the lossy compression before committing it by providing a preview round-trip. 
- Expose compression as a save option and make it available to queued conversions so batch jobs can produce compressed 8SVX files.

### Description
- Implemented compression/decompression and helpers in `SVXLoader.cs`, including `sCmpFibDelta`, big-endian chunk readers, `CompressFibonacciDelta`/`CompressFibonacciDeltaSigned`, `DecompressFibonacciDeltaSigned`, padded-nybble handling, and `RoundTripFibonacciDelta` for preview. 
- Added a `Fib Δ` checkbox (`checkBox8SVXFibDelta`) to the main UI and wired it so preview playback will apply the compression round-trip when checked. 
- Updated `SaveAs8SVX` to optionally write a Fibonacci-delta compressed BODY and set the VHDR compression byte accordingly, and adjusted chunk sizing and padding logic to match the spec. 
- Persisted the compression option into the queue by adding `Compress8Svx` to `QueueItem`, added a queue context-menu toggle (`queueToggle8SvxCompressionMenuItem`), and applied the setting when creating/applying queued item settings. 
- Minor robustness fixes to 8SVX parsing (big-endian reads, chunk padding/trimming and declared sample count handling). Files changed: `WavConvert4Amiga/SVXLoader.cs`, `WavConvert4Amiga/WavConvert4Amiga-Main.cs`, and `WavConvert4Amiga/QueueItem.cs`.

### Testing
- Ran static checks `git diff --check` which reported no whitespace/merge errors. 
- Verified repository status with `git status --short` and source changes are staged and committed locally. 
- Attempted a build tool check (`command -v msbuild; command -v xbuild; command -v csc; command -v mcs; command -v nuget`) but no .NET/MSBuild/C# compiler was available in this environment so a project build and runtime tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a203ac416f8832d8f02812058548708)